### PR TITLE
Avoid code signing when checking that the demo compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,30 +35,12 @@ jobs:
           check_name: 📋 Unit test report
           fail_on_failure: true
 
-  archive-demos:
-    name: 📦 Archives
+  build-demo:
+    name: 🔨 Build
     runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Add Apple certificate
-        run: |
-          Scripts/private/add-apple-certificate.sh \
-          $RUNNER_TEMP \
-          ${{ secrets.KEYCHAIN_PASSWORD }} \
-          ${{ secrets.APPLE_DEV_CERTIFICATE }} \
-          ${{ secrets.APPLE_DEV_CERTIFICATE_PASSWORD }}
-
-      - name: Configure environment
-        run: |
-          Scripts/private/configure-environment.sh \
-          ${{ secrets.APP_STORE_CONNECT_API_KEY }}
-
-      - name: Archive the demo
-        run: Scripts/private/archive-demo.sh
-        env:
-          TEAM_ID: ${{ secrets.TEAM_ID }}
-          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ISSUER_ID }}
-          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_GROUPS }}
+      - name: Build the demo
+        run: make build

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 .PHONY: all
 all: help
 
+.PHONY: build
+build:
+	@Scripts/public/build-demo.sh
+
 .PHONY: test
 test:
 	@Scripts/public/test.sh
@@ -38,8 +42,11 @@ help:
 	@echo "Default:"
 	@echo "  all                            Default target"
 	@echo
+	@echo "Build:"
+	@echo "  build                      	Build demo app"
+	@echo
 	@echo "Test:"
-	@echo "  test                           Build & run unit tests"
+	@echo "  test                           Build and run unit tests"
 	@echo
 	@echo "Quality:"
 	@echo "  check-quality                  Run quality checks"

--- a/Scripts/public/build-demo.sh
+++ b/Scripts/public/build-demo.sh
@@ -11,8 +11,8 @@ function install_tools {
 
 install_tools
 
-echo "Archiving demo..."
+echo "Building demo..."
 bundle config set path '.bundle'
 bundle install
-bundle exec fastlane archive_demo
+bundle exec fastlane build_demo
 echo "... done."

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -92,7 +92,19 @@ def bump_testflight_build_number(platform_id, configuration_id)
   build_number
 end
 
-def build_and_sign_app(platform_id, configuration_id)
+def build_demo_app(platform_id, configuration_id)
+  build_app(
+    project: 'Demo/Castor-demo.xcodeproj',
+    configuration: CONFIGURATIONS[configuration_id],
+    scheme: 'Castor-demo',
+    destination: "generic/platform=#{PLATFORMS[platform_id]}",
+    output_directory: 'Binaries',
+    skip_archive: true,
+    skip_codesigning: true
+  )
+end
+
+def build_and_sign_demo_app(platform_id, configuration_id)
   build_app(
     project: 'Demo/Castor-demo.xcodeproj',
     configuration: CONFIGURATIONS[configuration_id],
@@ -148,17 +160,16 @@ rescue StandardError => e
   UI.important('TestFlight external delivery was skipped because a build is already in review')
 end
 
-def archive_demo(platform_id)
-  ensure_configuration_availability
-  build_and_sign_app(platform_id, :nightly)
-  build_and_sign_app(platform_id, :release)
+def build_demo(platform_id)
+  build_demo_app(platform_id, :nightly)
+  build_demo_app(platform_id, :release)
 end
 
 def deliver_demo_nightly(platform_id)
   ensure_configuration_availability
   build_number = bump_testflight_build_number(platform_id, :nightly)
   add_version_badge(platform_id, last_git_tag, build_number, 'orange')
-  build_and_sign_app(platform_id, :nightly)
+  build_and_sign_demo_app(platform_id, :nightly)
   reset_git_repo(skip_clean: true)
   upload_app_to_testflight
   distribute_app_to_testers(platform_id, :nightly, build_number)
@@ -167,7 +178,7 @@ end
 def deliver_demo_release(platform_id)
   ensure_configuration_availability
   add_version_badge(platform_id, 'v.', last_git_tag, 'blue')
-  build_and_sign_app(platform_id, :release)
+  build_and_sign_demo_app(platform_id, :release)
   reset_git_repo(skip_clean: true)
   upload_app_to_testflight
   distribute_app_to_testers(platform_id, :release, xcconfig_build_number)
@@ -209,9 +220,9 @@ platform :ios do
     reset_git_repo(skip_clean: true)
   end
 
-  desc 'Archive the demo app'
-  lane :archive_demo do
-    archive_demo(:ios)
+  desc 'Build the demo app'
+  lane :build_demo do
+    build_demo(:ios)
   end
 
   desc 'Deliver a demo app nightly build'


### PR DESCRIPTION
## Description

This PR improves our CI workflow to make it possible to validate external PRs. GitHub namely [avoids exposing secrets](https://github.com/orgs/community/discussions/26242) when running workflows for external PRs, for security reasons.

To solve this issue we improved our workflows to avoid secrets in CI steps used mostly to check that the code compiles on all supported platforms.

## Changes made

- Provide target that build the demo without requiring secrets (no archiving).
- Rename _archiving_ to _build_ in associated targets.
- Update CI workflow to remove the need for secrets entirely.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
