### PR TITLE
Improve media queue item loading

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -176,16 +176,24 @@ private struct MediaQueueView: View {
 
     var body: some View {
         List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
-            ZStack {
-                if let title = item.title {
-                    Text(title)
-                }
-                else {
-                    ProgressView()
-                }
-            }
-            .onAppear(perform: item.load)
+            MediaQueueCell(item: item)
         }
+    }
+}
+
+private struct MediaQueueCell: View {
+    let item: CastPlayerItem
+
+    var body: some View {
+        ZStack {
+            if let title = item.title {
+                Text(title)
+            }
+            else {
+                ProgressView()
+            }
+        }
+        .onAppear(perform: item.load)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -175,7 +175,7 @@ private struct MediaQueueView: View {
     @ObservedObject var mediaQueue: MediaQueue
 
     var body: some View {
-        List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
+        List(mediaQueue.items, id: \.self) { item in
             MediaQueueCell(item: item)
                 .onAppear {
                     mediaQueue.load(item)

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -176,12 +176,15 @@ private struct MediaQueueView: View {
 
     var body: some View {
         List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
-            if let title = item.title {
-                Text(title)
+            ZStack {
+                if let title = item.title {
+                    Text("\(title) - \(item.id)")
+                }
+                else {
+                    Text("\(item.id)")
+                }
             }
-            else {
-                ProgressView()
-            }
+            .onAppear(perform: item.load)
         }
     }
 }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -188,14 +188,8 @@ private struct MediaQueueCell: View {
     let item: CastPlayerItem
 
     var body: some View {
-        Group {
-            if let title = item.title {
-                Text(title)
-            }
-            else {
-                ProgressView()
-            }
-        }
+        Text(item.title ?? String(repeating: " ", count: .random(in: 20...40)))
+            .redacted(reason: item.title == nil ? .placeholder : [])
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -177,6 +177,9 @@ private struct MediaQueueView: View {
     var body: some View {
         List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
             MediaQueueCell(item: item)
+                .onAppear {
+                    mediaQueue.load(item)
+                }
         }
     }
 }
@@ -185,7 +188,7 @@ private struct MediaQueueCell: View {
     let item: CastPlayerItem
 
     var body: some View {
-        ZStack {
+        Group {
             if let title = item.title {
                 Text(title)
             }
@@ -193,7 +196,6 @@ private struct MediaQueueCell: View {
                 ProgressView()
             }
         }
-        .onAppear(perform: item.load)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -178,10 +178,10 @@ private struct MediaQueueView: View {
         List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
             ZStack {
                 if let title = item.title {
-                    Text("\(title) - \(item.id)")
+                    Text(title)
                 }
                 else {
-                    Text("\(item.id)")
+                    ProgressView()
                 }
             }
             .onAppear(perform: item.load)

--- a/Demo/Sources/GoogleCast.swift
+++ b/Demo/Sources/GoogleCast.swift
@@ -72,23 +72,6 @@ class GoogleCast: NSObject, ObservableObject {
             .sharedInstance().sessionManager.currentSession?.remoteMediaClient?
             .queueInsert(streams.map(queueItem(from:)), beforeItemWithID: kGCKMediaQueueInvalidItemID)
     }
-
-    static func update() {
-        let remoteMediaClient = GCKCastContext
-            .sharedInstance().sessionManager.currentSession?.remoteMediaClient
-        if let firstItem = remoteMediaClient?.mediaQueue.item(at: 0) {
-            let copy = firstItem.mediaQueueItemModified { builder in
-                if let mediaInformation = builder.mediaInformation {
-                    let mediaInformationBuilder = GCKMediaInformationBuilder(mediaInformation: mediaInformation)
-                    let metadata = GCKMediaMetadata()
-                    metadata.setString("Dummy", forKey: kGCKMetadataKeyTitle)
-                    mediaInformationBuilder.metadata = metadata
-                    builder.mediaInformation = mediaInformationBuilder.build()
-                }
-            }
-            remoteMediaClient?.queueUpdate([copy])
-        }
-    }
 }
 
 extension GoogleCast: GCKSessionManagerListener {

--- a/Demo/Sources/GoogleCast.swift
+++ b/Demo/Sources/GoogleCast.swift
@@ -72,6 +72,23 @@ class GoogleCast: NSObject, ObservableObject {
             .sharedInstance().sessionManager.currentSession?.remoteMediaClient?
             .queueInsert(streams.map(queueItem(from:)), beforeItemWithID: kGCKMediaQueueInvalidItemID)
     }
+
+    static func update() {
+        let remoteMediaClient = GCKCastContext
+            .sharedInstance().sessionManager.currentSession?.remoteMediaClient
+        if let firstItem = remoteMediaClient?.mediaQueue.item(at: 0) {
+            let copy = firstItem.mediaQueueItemModified { builder in
+                if let mediaInformation = builder.mediaInformation {
+                    let mediaInformationBuilder = GCKMediaInformationBuilder(mediaInformation: mediaInformation)
+                    let metadata = GCKMediaMetadata()
+                    metadata.setString("Dummy", forKey: kGCKMetadataKeyTitle)
+                    mediaInformationBuilder.metadata = metadata
+                    builder.mediaInformation = mediaInformationBuilder.build()
+                }
+            }
+            remoteMediaClient?.queueUpdate([copy])
+        }
+    }
 }
 
 extension GoogleCast: GCKSessionManagerListener {

--- a/Demo/Sources/GoogleCast.swift
+++ b/Demo/Sources/GoogleCast.swift
@@ -66,6 +66,12 @@ class GoogleCast: NSObject, ObservableObject {
             .sharedInstance().sessionManager.currentSession?.remoteMediaClient?
             .queueInsert(queueItem(from: stream), beforeItemWithID: kGCKMediaQueueInvalidItemID)
     }
+
+    static func append(streams: [Stream]) {
+        _ = GCKCastContext
+            .sharedInstance().sessionManager.currentSession?.remoteMediaClient?
+            .queueInsert(streams.map(queueItem(from:)), beforeItemWithID: kGCKMediaQueueInvalidItemID)
+    }
 }
 
 extension GoogleCast: GCKSessionManagerListener {

--- a/Demo/Sources/StreamsView.swift
+++ b/Demo/Sources/StreamsView.swift
@@ -80,11 +80,6 @@ struct StreamsView: View {
                     Text("Append")
                 }
             }
-            ToolbarItem(placement: .topBarLeading) {
-                Button(action: update) {
-                    Text("Update")
-                }
-            }
             ToolbarItem(placement: .topBarTrailing) {
                 CastButton()
             }
@@ -103,11 +98,6 @@ struct StreamsView: View {
     private func append() {
         guard googleCast.isActive, let stream = streams.randomElement() else { return }
         GoogleCast.append(stream: stream)
-    }
-
-    private func update() {
-        guard googleCast.isActive, let stream = streams.randomElement() else { return }
-        GoogleCast.update()
     }
 }
 

--- a/Demo/Sources/StreamsView.swift
+++ b/Demo/Sources/StreamsView.swift
@@ -92,12 +92,12 @@ struct StreamsView: View {
 
     private func batchLoad() {
         guard googleCast.isActive else { return }
-        GoogleCast.load(streams: streams + streams + streams + streams)
+        GoogleCast.load(streams: Array(repeating: streams.first!, count: 170))
     }
 
     private func append() {
-        guard googleCast.isActive, let stream = streams.randomElement() else { return }
-        GoogleCast.append(stream: stream)
+        guard googleCast.isActive else { return }
+        GoogleCast.append(streams: streams)
     }
 }
 

--- a/Demo/Sources/StreamsView.swift
+++ b/Demo/Sources/StreamsView.swift
@@ -92,12 +92,12 @@ struct StreamsView: View {
 
     private func batchLoad() {
         guard googleCast.isActive else { return }
-        GoogleCast.load(streams: Array(repeating: streams.first!, count: 170))
+        GoogleCast.load(streams: streams + streams + streams + streams)
     }
 
     private func append() {
-        guard googleCast.isActive else { return }
-        GoogleCast.append(streams: streams)
+        guard googleCast.isActive, let stream = streams.randomElement() else { return }
+        GoogleCast.append(stream: stream)
     }
 }
 

--- a/Demo/Sources/StreamsView.swift
+++ b/Demo/Sources/StreamsView.swift
@@ -80,6 +80,11 @@ struct StreamsView: View {
                     Text("Append")
                 }
             }
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: update) {
+                    Text("Update")
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 CastButton()
             }
@@ -98,6 +103,11 @@ struct StreamsView: View {
     private func append() {
         guard googleCast.isActive, let stream = streams.randomElement() else { return }
         GoogleCast.append(stream: stream)
+    }
+
+    private func update() {
+        guard googleCast.isActive, let stream = streams.randomElement() else { return }
+        GoogleCast.update()
     }
 }
 

--- a/Sources/Castor/CastCachedPlayerItem.swift
+++ b/Sources/Castor/CastCachedPlayerItem.swift
@@ -20,12 +20,7 @@ final class CastCachedPlayerItem: NSObject {
 
     func load() {
         guard rawItem == nil else { return }
-        if let item = queue.item(withID: id, fetchIfNeeded: false) {
-            rawItem = item
-        }
-        else if let item = queue.item(withID: id) {
-            rawItem = item
-        }
+        rawItem = queue.item(withID: id, fetchIfNeeded: false) ?? queue.item(withID: id)
     }
 
     func toItem() -> CastPlayerItem {

--- a/Sources/Castor/CastCachedPlayerItem.swift
+++ b/Sources/Castor/CastCachedPlayerItem.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+final class CastCachedPlayerItem: NSObject {
+    let id: GCKMediaQueueItemID
+    let queue: GCKMediaQueue
+    private var rawItem: GCKMediaQueueItem?
+
+    init(id: GCKMediaQueueItemID, queue: GCKMediaQueue) {
+        self.id = id
+        self.queue = queue
+        super.init()
+        queue.add(self)
+    }
+
+    func load() {
+        guard rawItem == nil else { return }
+        if let item = queue.item(withID: id, fetchIfNeeded: false) {
+            rawItem = item
+        }
+        else if let item = queue.item(withID: id) {
+            rawItem = item
+        }
+    }
+
+    func toItem() -> CastPlayerItem {
+        .init(id: id, rawItem: rawItem)
+    }
+}
+
+extension CastCachedPlayerItem: GCKMediaQueueDelegate {
+    // swiftlint:disable:next legacy_objc_type
+    func mediaQueue(_ queue: GCKMediaQueue, didUpdateItemsAtIndexes indexes: [NSNumber]) {
+        if let item = queue.item(withID: id, fetchIfNeeded: false) {
+            rawItem = item
+        }
+    }
+}

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -43,7 +43,12 @@ public class CastPlayerItem: NSObject {
     }
 
     public func load() {
-        print("--> load \(id)")
+        if let item = queue.item(withID: id, fetchIfNeeded: false) {
+            cachedRawItem = item
+        }
+        else if let item = queue.item(withID: id) {
+            cachedRawItem = item
+        }
     }
 }
 

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -43,12 +43,8 @@ public class CastPlayerItem: NSObject {
     }
 
     public func load() {
-        if let item = queue.item(withID: id, fetchIfNeeded: false) {
-            cachedRawItem = item
-        }
-        else if let item = queue.item(withID: id) {
-            cachedRawItem = item
-        }
+        guard let item = queue.item(withID: id, fetchIfNeeded: false) ?? queue.item(withID: id) else { return }
+        cachedRawItem = item
     }
 }
 

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -22,6 +22,10 @@ public class CastPlayerItem: NSObject {
         if let cachedRawItem {
             return cachedRawItem
         }
+        else if let item = queue.item(withID: id, fetchIfNeeded: false) {
+            cachedRawItem = item
+            return item
+        }
         else {
             return nil
         }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -8,7 +8,7 @@ import GoogleCast
 
 /// A cast player item.
 public class CastPlayerItem: NSObject {
-    let id: GCKMediaQueueItemID
+    public let id: GCKMediaQueueItemID
 
     private let queue: GCKMediaQueue
     private var cachedRawItem: GCKMediaQueueItem?
@@ -22,12 +22,8 @@ public class CastPlayerItem: NSObject {
         if let cachedRawItem {
             return cachedRawItem
         }
-        else if let item = queue.item(withID: id, fetchIfNeeded: false) {
-            cachedRawItem = item
-            return item
-        }
         else {
-            return queue.item(withID: id)
+            return nil
         }
     }
 
@@ -44,6 +40,10 @@ public class CastPlayerItem: NSObject {
 
     override public func isEqual(_ object: Any?) -> Bool {
         (object as? Self)?.id == id
+    }
+
+    public func load() {
+        print("--> load \(id)")
     }
 }
 

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -7,56 +7,12 @@
 import GoogleCast
 
 /// A cast player item.
-public class CastPlayerItem: NSObject {
+public struct CastPlayerItem: Hashable {
     let id: GCKMediaQueueItemID
-
-    private let queue: GCKMediaQueue
-    private var cachedRawItem: GCKMediaQueueItem?
+    let rawItem: GCKMediaQueueItem?
 
     /// The content title.
     public var title: String? {
         rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
-    }
-
-    private var rawItem: GCKMediaQueueItem? {
-        if let cachedRawItem {
-            return cachedRawItem
-        }
-        else if let item = queue.item(withID: id, fetchIfNeeded: false) {
-            cachedRawItem = item
-            return item
-        }
-        else {
-            return nil
-        }
-    }
-
-    override public var hash: Int {
-        Int(id)
-    }
-
-    init(id: GCKMediaQueueItemID, queue: GCKMediaQueue) {
-        self.id = id
-        self.queue = queue
-        super.init()
-        queue.add(self)
-    }
-
-    override public func isEqual(_ object: Any?) -> Bool {
-        (object as? Self)?.id == id
-    }
-
-    public func load() {
-        guard let item = queue.item(withID: id, fetchIfNeeded: false) ?? queue.item(withID: id) else { return }
-        cachedRawItem = item
-    }
-}
-
-extension CastPlayerItem: GCKMediaQueueDelegate {
-    // swiftlint:disable:next legacy_objc_type missing_docs
-    public func mediaQueue(_ queue: GCKMediaQueue, didUpdateItemsAtIndexes indexes: [NSNumber]) {
-        if let item = queue.item(withID: id, fetchIfNeeded: false) {
-            cachedRawItem = item
-        }
     }
 }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -8,7 +8,7 @@ import GoogleCast
 
 /// A cast player item.
 public class CastPlayerItem: NSObject {
-    public let id: GCKMediaQueueItemID
+    let id: GCKMediaQueueItemID
 
     private let queue: GCKMediaQueue
     private var cachedRawItem: GCKMediaQueueItem?

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -55,13 +55,8 @@ extension MediaQueue: GCKMediaQueueDelegate {
         cachedItems.remove(atOffsets: IndexSet(indexes.map(\.intValue)))
     }
 
-    public func mediaQueue(_ queue: GCKMediaQueue, didUpdateItemsAtIndexes indexes: [NSNumber]) {
-        print("--> update")
-    }
-
     // swiftlint:disable:next missing_docs
     public func mediaQueueDidChange(_ queue: GCKMediaQueue) {
         items = cachedItems.map { $0.toItem() }
-        print("--> \(items.first?.title)")
     }
 }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -11,51 +11,15 @@ import SwiftUI
 public final class MediaQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
 
-    @Published private var mediaStatus: GCKMediaStatus? {
-        didSet {
-            guard request == nil else { return }
-            currentCachedItem = Self.currentItem(for: remoteMediaClient.mediaStatus, queue: remoteMediaClient.mediaQueue)
-        }
-    }
-
     private var cachedItems: [CastCachedPlayerItem] = []
 
     /// The items in the queue.
     @Published public private(set) var items: [CastPlayerItem] = []
 
-    private weak var request: GCKRequest?
-
-    private var currentCachedItem: CastCachedPlayerItem? {
-        didSet {
-            guard request == nil, oldValue != currentCachedItem, let currentCachedItem else { return }
-            request = remoteMediaClient.queueJumpToItem(withID: currentCachedItem.id)
-            request?.delegate = self
-        }
-    }
-
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
-        mediaStatus = remoteMediaClient.mediaStatus
-        currentCachedItem = Self.currentItem(for: remoteMediaClient.mediaStatus, queue: remoteMediaClient.mediaQueue)
         super.init()
-        remoteMediaClient.add(self)
         remoteMediaClient.mediaQueue.add(self)
-    }
-
-    private static func currentItem(for mediaStatus: GCKMediaStatus?, queue: GCKMediaQueue) -> CastCachedPlayerItem? {
-        guard let rawItem = mediaStatus?.currentQueueItem else { return nil }
-        return CastCachedPlayerItem(id: rawItem.itemID, queue: queue)
-    }
-
-    /// Current item.
-    public func item() -> Binding<CastPlayerItem?> {
-        .init { [weak self] in
-            self?.currentCachedItem?.toItem()
-        } set: { [weak self] newValue in
-            if let self, let newValue {
-                currentCachedItem = .init(id: newValue.id, queue: remoteMediaClient.mediaQueue)
-            }
-        }
     }
 
     /// Try to load a `CastPlayerItem` from the cache.
@@ -64,13 +28,6 @@ public final class MediaQueue: NSObject, ObservableObject {
     public func load(_ item: CastPlayerItem) {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
         cachedItem.load()
-    }
-}
-
-extension MediaQueue: GCKRemoteMediaClientListener {
-    // swiftlint:disable:next missing_docs
-    public func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        self.mediaStatus = mediaStatus
     }
 }
 
@@ -101,15 +58,5 @@ extension MediaQueue: GCKMediaQueueDelegate {
     // swiftlint:disable:next missing_docs
     public func mediaQueueDidChange(_ queue: GCKMediaQueue) {
         items = cachedItems.map { $0.toItem() }
-    }
-}
-
-extension MediaQueue: GCKRequestDelegate {
-    // swiftlint:disable:next missing_docs
-    public func requestDidComplete(_ request: GCKRequest) {
-        if let itemID = currentCachedItem?.id, itemID != remoteMediaClient.mediaStatus?.currentItemID {
-            self.request = remoteMediaClient.queueJumpToItem(withID: itemID)
-            self.request?.delegate = self
-        }
     }
 }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -22,9 +22,9 @@ public final class MediaQueue: NSObject, ObservableObject {
         remoteMediaClient.mediaQueue.add(self)
     }
 
-    /// Try to load a `CastPlayerItem` from the cache.
+    /// Load a `CastPlayerItem`.
     ///
-    /// - Parameter item: The item to load from the cache.
+    /// - Parameter item: The item to load.
     public func load(_ item: CastPlayerItem) {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
         cachedItem.load()

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -55,8 +55,13 @@ extension MediaQueue: GCKMediaQueueDelegate {
         cachedItems.remove(atOffsets: IndexSet(indexes.map(\.intValue)))
     }
 
+    public func mediaQueue(_ queue: GCKMediaQueue, didUpdateItemsAtIndexes indexes: [NSNumber]) {
+        print("--> update")
+    }
+
     // swiftlint:disable:next missing_docs
     public func mediaQueueDidChange(_ queue: GCKMediaQueue) {
         items = cachedItems.map { $0.toItem() }
+        print("--> \(items.first?.title)")
     }
 }


### PR DESCRIPTION
## Description

This PR enhances the media queue loading.

## Changes made

- A dedicated cell has been created for media queue items.
- The `CastPlayerItem` has been converted to a struct to avoid using a class in SwiftUI side.
- The selection has been removed temporarily to stay focused on the main purpose (items loading).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
