### PR TITLE
Improve device selection management

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -199,7 +199,7 @@ struct CastPlayerView: View {
     var body: some View {
         ZStack {
             if let player = cast.player {
-                MainView(player: player, device: cast.device().wrappedValue)
+                MainView(player: player, device: cast.device)
             }
             else {
                 ContentUnavailableView("Not connected", systemImage: "wifi.slash")

--- a/Demo/Sources/DevicesView.swift
+++ b/Demo/Sources/DevicesView.swift
@@ -20,6 +20,7 @@ private struct NoDevicesView: View {
 
 struct DevicesView: View {
     @EnvironmentObject private var cast: Cast
+    @State private var device: CastDevice?
 
     var body: some View {
         ZStack {
@@ -37,16 +38,6 @@ struct DevicesView: View {
         }
     }
 
-    private var selection: Binding<CastDevice?> {
-        .init {
-            cast.device
-        } set: { device in
-            if let device {
-                cast.startSession(with: device)
-            }
-        }
-    }
-
     private static func imageName(for device: CastDevice) -> String {
         switch device.type {
         case .TV:
@@ -61,7 +52,7 @@ struct DevicesView: View {
     }
 
     private func devicesView() -> some View {
-        List(cast.devices, id: \.self, selection: selection) { device in
+        List(cast.devices, id: \.self, selection: $device) { device in
             HStack {
                 Image(systemName: Self.imageName(for: device))
                 descriptionView(for: device)
@@ -70,6 +61,14 @@ struct DevicesView: View {
                     statusView()
                 }
             }
+        }
+        .onChange(of: device) {
+            if let device {
+                cast.startSession(with: device)
+            }
+        }
+        .onAppear {
+            device = cast.device
         }
     }
 

--- a/Demo/Sources/DevicesView.swift
+++ b/Demo/Sources/DevicesView.swift
@@ -62,17 +62,7 @@ struct DevicesView: View {
                 }
             }
         }
-        .onChange(of: device) {
-            if let device {
-                cast.startSession(with: device)
-            }
-        }
-        .onChange(of: cast.device) {
-            device = cast.device
-        }
-        .onAppear {
-            device = cast.device
-        }
+        .bind($device, to: cast)
     }
 
     @ViewBuilder

--- a/Demo/Sources/DevicesView.swift
+++ b/Demo/Sources/DevicesView.swift
@@ -37,6 +37,16 @@ struct DevicesView: View {
         }
     }
 
+    private var selection: Binding<CastDevice?> {
+        .init {
+            cast.device
+        } set: { device in
+            if let device {
+                cast.startSession(with: device)
+            }
+        }
+    }
+
     private static func imageName(for device: CastDevice) -> String {
         switch device.type {
         case .TV:
@@ -51,7 +61,7 @@ struct DevicesView: View {
     }
 
     private func devicesView() -> some View {
-        List(cast.devices, id: \.self, selection: cast.device()) { device in
+        List(cast.devices, id: \.self, selection: selection) { device in
             HStack {
                 Image(systemName: Self.imageName(for: device))
                 descriptionView(for: device)

--- a/Demo/Sources/DevicesView.swift
+++ b/Demo/Sources/DevicesView.swift
@@ -67,6 +67,9 @@ struct DevicesView: View {
                 cast.startSession(with: device)
             }
         }
+        .onChange(of: cast.device) {
+            device = cast.device
+        }
         .onAppear {
             device = cast.device
         }

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -19,6 +19,8 @@ public final class Cast: NSObject, ObservableObject {
         }
     }
 
+    private var targetDevice: CastDevice?
+
     /// The current device.
     @Published public private(set) var device: CastDevice?
 
@@ -54,8 +56,13 @@ public final class Cast: NSObject, ObservableObject {
     /// - Parameter device: The device to use for this session.
     public func startSession(with device: CastDevice) {
         guard self.device != device else { return }
-        endSession()
-        context.sessionManager.startSession(with: device.rawDevice)
+        if self.device != nil {
+            self.targetDevice = device
+            endSession()
+        }
+        else {
+            context.sessionManager.startSession(with: device.rawDevice)
+        }
     }
 
     /// Ends the current session and stops casting if one sender device is connected.
@@ -123,12 +130,9 @@ extension Cast: GCKSessionManagerListener {
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, didEnd session: GCKCastSession, withError error: (any Error)?) {
         currentSession = sessionManager.currentCastSession
-
-        if let device, session.device.toCastDevice() != device {
-            sessionManager.startSession(with: device.rawDevice)
-        }
-        else {
-            device = nil
+        if let targetDevice {
+            sessionManager.startSession(with: targetDevice.rawDevice)
+            self.targetDevice = nil
         }
     }
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -57,7 +57,7 @@ public final class Cast: NSObject, ObservableObject {
     public func startSession(with device: CastDevice) {
         guard self.device != device else { return }
         if self.device != nil {
-            self.targetDevice = device
+            targetDevice = device
             endSession()
         }
         else {
@@ -130,11 +130,12 @@ extension Cast: GCKSessionManagerListener {
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, didEnd session: GCKCastSession, withError error: (any Error)?) {
         currentSession = sessionManager.currentCastSession
-        device = nil
-
         if let targetDevice {
             sessionManager.startSession(with: targetDevice.rawDevice)
             self.targetDevice = nil
+        }
+        else {
+            device = nil
         }
     }
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -54,7 +54,6 @@ public final class Cast: NSObject, ObservableObject {
     /// - Parameter device: The device to use for this session.
     public func startSession(with device: CastDevice) {
         guard self.device != device else { return }
-        self.device = device
         endSession()
         context.sessionManager.startSession(with: device.rawDevice)
     }

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -130,6 +130,8 @@ extension Cast: GCKSessionManagerListener {
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, didEnd session: GCKCastSession, withError error: (any Error)?) {
         currentSession = sessionManager.currentCastSession
+        device = nil
+
         if let targetDevice {
             sessionManager.startSession(with: targetDevice.rawDevice)
             self.targetDevice = nil

--- a/Sources/Castor/Extensions/List.swift
+++ b/Sources/Castor/Extensions/List.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+public extension List where SelectionValue == CastDevice {
+    /// Binds a device state to a cast context.
+    ///
+    /// - Parameters:
+    ///   - device: The device binding.
+    ///   - cast: The cast context.
+    func bind(_ device: Binding<CastDevice?>, to cast: Cast) -> some View {
+        onChange(of: device.wrappedValue) { newDevice in
+            if let newDevice {
+                cast.startSession(with: newDevice)
+            }
+        }
+        .onChange(of: cast.device) { newDevice in
+            device.wrappedValue = newDevice
+        }
+        .onAppear {
+            device.wrappedValue = cast.device
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR improves device selection management to avoid UI updates being triggered from other UI updates (in this case a binding updating a published property).

## Changes made

- Remove current device binding from `Cast` object.
- Introduce list modifier that makes it possible to bind a local current device state, managing user selection, with the `Cast` context.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
