### PR TITLE
Improve media queue item selection

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -173,14 +173,16 @@ private struct MainView: View {
 
 private struct MediaQueueView: View {
     @ObservedObject var mediaQueue: MediaQueue
+    @State private var currentItem: CastPlayerItem?
 
     var body: some View {
-        List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
+        List(mediaQueue.items, id: \.self, selection: $currentItem) { item in
             MediaQueueCell(item: item)
                 .onAppear {
                     mediaQueue.load(item)
                 }
         }
+        .bind($currentItem, to: mediaQueue)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -175,7 +175,7 @@ private struct MediaQueueView: View {
     @ObservedObject var mediaQueue: MediaQueue
 
     var body: some View {
-        List(mediaQueue.items, id: \.self) { item in
+        List(mediaQueue.items, id: \.self, selection: mediaQueue.item()) { item in
             MediaQueueCell(item: item)
                 .onAppear {
                     mediaQueue.load(item)

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -8,7 +8,7 @@ import GoogleCast
 
 final class CastCurrent: NSObject {
     private let remoteMediaClient: GCKRemoteMediaClient
-    var item: CastPlayerItem?
+    @Published var item: CastPlayerItem?
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -8,7 +8,7 @@ import GoogleCast
 
 final class CastCurrent: NSObject {
     private let remoteMediaClient: GCKRemoteMediaClient
-    @Published var item: CastPlayerItem?
+    var item: CastPlayerItem?
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -18,12 +18,7 @@ final class CastCurrent: NSObject {
     private var itemId: GCKMediaQueueItemID?
     private var requestItemId: GCKMediaQueueItemID?
 
-    weak var delegate: CastCurrentDelegate? {
-        didSet {
-            guard let mediaStatus = remoteMediaClient.mediaStatus else { return }
-            updateItem(for: mediaStatus)
-        }
-    }
+    weak var delegate: CastCurrentDelegate?
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
@@ -37,11 +32,6 @@ final class CastCurrent: NSObject {
             request = jumpRequest(to: item.id)
         }
         itemId = item.id
-    }
-
-    private func updateItem(for mediaStatus: GCKMediaStatus) {
-        guard mediaStatus.currentItemID == itemId else { return }
-        delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem))
     }
 
     private func jumpRequest(to itemID: GCKMediaQueueItemID) -> GCKRequest {
@@ -58,7 +48,9 @@ extension CastCurrent: GCKRemoteMediaClientListener {
         if itemId == nil {
             itemId = mediaStatus.currentItemID
         }
-        updateItem(for: mediaStatus)
+        if mediaStatus.currentItemID == itemId {
+            delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem))
+        }
     }
 }
 

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+final class CastCurrent: NSObject {
+    private let remoteMediaClient: GCKRemoteMediaClient
+    var item: CastPlayerItem?
+
+    init(remoteMediaClient: GCKRemoteMediaClient) {
+        self.remoteMediaClient = remoteMediaClient
+        if let status = remoteMediaClient.mediaStatus {
+            self.item = .init(id: status.currentItemID, rawItem: status.currentQueueItem)
+        }
+        super.init()
+        remoteMediaClient.add(self)
+    }
+}
+
+extension CastCurrent: GCKRemoteMediaClientListener {
+}

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -28,6 +28,7 @@ final class CastCurrent: NSObject {
     func jump(to item: CastPlayerItem) {
         let request = remoteMediaClient.queueJumpToItem(withID: item.id)
         request.delegate = self
+        print("--> [request] \(request.requestID) did start, inProgress = \(request.inProgress)")
     }
 }
 
@@ -40,12 +41,13 @@ private extension CastCurrent {
 
 extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
+        print("--> [status] did update, current \(mediaStatus?.currentItemID)")
         delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
     }
 }
 
 extension CastCurrent: GCKRequestDelegate {
     func requestDidComplete(_ request: GCKRequest) {
-
+        print("--> [request] \(request.requestID) did complete, inProgress = \(request.inProgress)")
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -12,8 +12,8 @@ final class CastCurrent: NSObject {
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
-        if let status = remoteMediaClient.mediaStatus {
-            self.item = .init(id: status.currentItemID, rawItem: status.currentQueueItem)
+        if let mediaStatus = remoteMediaClient.mediaStatus {
+            item = .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem)
         }
         super.init()
         remoteMediaClient.add(self)
@@ -21,4 +21,13 @@ final class CastCurrent: NSObject {
 }
 
 extension CastCurrent: GCKRemoteMediaClientListener {
+    func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
+        if let mediaStatus {
+            print("--> \(mediaStatus.currentItemID)")
+            item = .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem)
+        }
+        else {
+            item = nil
+        }
+    }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -6,13 +6,20 @@
 
 import GoogleCast
 
+protocol CastCurrentDelegate: AnyObject {
+    func didUpdate(item: CastPlayerItem?)
+}
+
 final class CastCurrent: NSObject {
     private let remoteMediaClient: GCKRemoteMediaClient
-    var item: CastPlayerItem?
+    weak var delegate: CastCurrentDelegate? {
+        didSet {
+            delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
+        }
+    }
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
-        self.item = Self.item(from: remoteMediaClient.mediaStatus)
         super.init()
         remoteMediaClient.add(self)
     }
@@ -25,6 +32,6 @@ final class CastCurrent: NSObject {
 
 extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        item = Self.item(from: remoteMediaClient.mediaStatus)
+        delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -18,7 +18,9 @@ final class CastCurrent: NSObject {
 
     weak var delegate: CastCurrentDelegate? {
         didSet {
-            delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
+            if mediaStatus.currentItemID == itemID {
+                delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
+            }
         }
     }
 

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -56,8 +56,7 @@ extension CastCurrent: GCKRemoteMediaClientListener {
 
 extension CastCurrent: GCKRequestDelegate {
     func requestDidComplete(_ request: GCKRequest) {
-        if let itemId, itemId != requestItemId {
-            self.request = jumpRequest(to: itemId)
-        }
+        guard let itemId, itemId != requestItemId else { return }
+        self.request = jumpRequest(to: itemId)
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -18,9 +18,8 @@ final class CastCurrent: NSObject {
 
     weak var delegate: CastCurrentDelegate? {
         didSet {
-            if remoteMediaClient.mediaStatus?.currentItemID == itemID {
-                delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
-            }
+            guard let mediaStatus = remoteMediaClient.mediaStatus else { return }
+            updateItem(for: mediaStatus)
         }
     }
 
@@ -40,12 +39,10 @@ final class CastCurrent: NSObject {
         }
         itemID = item.id
     }
-}
 
-private extension CastCurrent {
-    private static func item(from mediaStatus: GCKMediaStatus?) -> CastPlayerItem? {
-        guard let mediaStatus else { return nil }
-        return .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem)
+    private func updateItem(for mediaStatus: GCKMediaStatus) {
+        guard mediaStatus.currentItemID == itemID else { return }
+        delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem))
     }
 }
 
@@ -55,9 +52,7 @@ extension CastCurrent: GCKRemoteMediaClientListener {
         if itemID == nil {
             itemID = mediaStatus.currentItemID
         }
-        if mediaStatus.currentItemID == itemID {
-            delegate?.didUpdate(item: Self.item(from: mediaStatus))
-        }
+        updateItem(for: mediaStatus)
     }
 }
 

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -12,18 +12,10 @@ protocol CastCurrentDelegate: AnyObject {
 
 final class CastCurrent: NSObject {
     private let remoteMediaClient: GCKRemoteMediaClient
-    private var jumpRequest: GCKRequest?
-    private var lastTargetItem: CastPlayerItem?
-
-    private var isJumping: Bool {
-        jumpRequest != nil
-    }
 
     weak var delegate: CastCurrentDelegate? {
         didSet {
-            if !isJumping {
-                delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
-            }
+            delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
         }
     }
 
@@ -34,13 +26,8 @@ final class CastCurrent: NSObject {
     }
 
     func jump(to item: CastPlayerItem) {
-        if jumpRequest == nil {
-            jumpRequest = remoteMediaClient.queueJumpToItem(withID: item.id)
-            jumpRequest?.delegate = self
-        }
-        else {
-            lastTargetItem = item
-        }
+        let request = remoteMediaClient.queueJumpToItem(withID: item.id)
+        request.delegate = self
     }
 }
 
@@ -53,21 +40,12 @@ private extension CastCurrent {
 
 extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        if !isJumping {
-            delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
-        }
+        delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
     }
 }
 
 extension CastCurrent: GCKRequestDelegate {
     func requestDidComplete(_ request: GCKRequest) {
-        if let target = lastTargetItem {
-            jumpRequest = remoteMediaClient.queueJumpToItem(withID: target.id)
-            jumpRequest?.delegate = self
-            lastTargetItem = nil
-        }
-        else {
-            jumpRequest = nil
-        }
+
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -33,7 +33,6 @@ final class CastCurrent: NSObject {
         if request == nil {
             let request = remoteMediaClient.queueJumpToItem(withID: item.id)
             request.delegate = self
-            print("--> [request] \(request.requestID) did start, inProgress = \(request.inProgress)")
             self.request = request
             requestItemID = item.id
         }
@@ -50,7 +49,6 @@ private extension CastCurrent {
 
 extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        print("--> [status] did update, current \(mediaStatus?.currentItemID)")
         guard let mediaStatus else { return }
         if itemID == nil {
             itemID = mediaStatus.currentItemID
@@ -63,11 +61,9 @@ extension CastCurrent: GCKRemoteMediaClientListener {
 
 extension CastCurrent: GCKRequestDelegate {
     func requestDidComplete(_ request: GCKRequest) {
-        print("--> [request] \(request.requestID) did complete, inProgress = \(request.inProgress)")
         if let itemID, itemID != requestItemID {
             let request = remoteMediaClient.queueJumpToItem(withID: itemID)
             request.delegate = self
-            print("--> [request] \(request.requestID) did start, inProgress = \(request.inProgress)")
             self.request = request
             requestItemID = itemID
         }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -18,7 +18,7 @@ final class CastCurrent: NSObject {
 
     weak var delegate: CastCurrentDelegate? {
         didSet {
-            if mediaStatus.currentItemID == itemID {
+            if remoteMediaClient.mediaStatus?.currentItemID == itemID {
                 delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
             }
         }
@@ -56,7 +56,7 @@ extension CastCurrent: GCKRemoteMediaClientListener {
             itemID = mediaStatus.currentItemID
         }
         if mediaStatus.currentItemID == itemID {
-            delegate?.didUpdate(item: Self.item(from: remoteMediaClient.mediaStatus))
+            delegate?.didUpdate(item: Self.item(from: mediaStatus))
         }
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -12,22 +12,19 @@ final class CastCurrent: NSObject {
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
-        if let mediaStatus = remoteMediaClient.mediaStatus {
-            item = .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem)
-        }
+        self.item = Self.item(from: remoteMediaClient.mediaStatus)
         super.init()
         remoteMediaClient.add(self)
+    }
+
+    private static func item(from mediaStatus: GCKMediaStatus?) -> CastPlayerItem? {
+        guard let mediaStatus else { return nil }
+        return .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem)
     }
 }
 
 extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        if let mediaStatus {
-            print("--> \(mediaStatus.currentItemID)")
-            item = .init(id: mediaStatus.currentItemID, rawItem: mediaStatus.currentQueueItem)
-        }
-        else {
-            item = nil
-        }
+        item = Self.item(from: remoteMediaClient.mediaStatus)
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -14,7 +14,6 @@ final class CastCurrent: NSObject {
     private let remoteMediaClient: GCKRemoteMediaClient
 
     private weak var request: GCKRequest?
-
     private var requestItemId: GCKMediaQueueItemID?
     private var pendingRequestItemId: GCKMediaQueueItemID?
 

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -9,12 +9,15 @@ import GoogleCast
 /// A cast player item.
 public struct CastPlayerItem: Hashable {
     let id: GCKMediaQueueItemID
+    let rawItem: GCKMediaQueueItem?
 
     /// The content title.
-    public let title: String?
+    public var title: String? {
+        rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
+    }
 
-    init(id: GCKMediaQueueItemID, rawItem: GCKMediaQueueItem?) {
-        self.id = id
-        self.title = rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
+    // swiftlint:disable:next missing_docs
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id && lhs.rawItem?.itemID == rhs.rawItem?.itemID
     }
 }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -9,15 +9,12 @@ import GoogleCast
 /// A cast player item.
 public struct CastPlayerItem: Hashable {
     let id: GCKMediaQueueItemID
-    let rawItem: GCKMediaQueueItem?
 
     /// The content title.
-    public var title: String? {
-        rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
-    }
+    public let title: String?
 
-    // swiftlint:disable:next missing_docs
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id && lhs.rawItem?.itemID == rhs.rawItem?.itemID
+    init(id: GCKMediaQueueItemID, rawItem: GCKMediaQueueItem?) {
+        self.id = id
+        self.title = rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
     }
 }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -15,4 +15,9 @@ public struct CastPlayerItem: Hashable {
     public var title: String? {
         rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
     }
+
+    // swiftlint:disable:next missing_docs
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id && lhs.rawItem?.itemID == rhs.rawItem?.itemID
+    }
 }

--- a/Sources/Castor/Extensions/List.swift
+++ b/Sources/Castor/Extensions/List.swift
@@ -34,8 +34,10 @@ public extension List where SelectionValue == CastPlayerItem {
     ///   - currentItem: The current item binding.
     ///   - mediaQueue: The media queue.
     func bind(_ currentItem: Binding<CastPlayerItem?>, to mediaQueue: MediaQueue) -> some View {
-        onChange(of: currentItem.wrappedValue) { _ in
-            // TODO: Jump to the item!
+        onChange(of: currentItem.wrappedValue) { item in
+            if let item {
+                mediaQueue.jump(to: item)
+            }
         }
         .onChange(of: mediaQueue.currentItem) { item in
             currentItem.wrappedValue = item

--- a/Sources/Castor/Extensions/List.swift
+++ b/Sources/Castor/Extensions/List.swift
@@ -26,3 +26,22 @@ public extension List where SelectionValue == CastDevice {
         }
     }
 }
+
+public extension List where SelectionValue == CastPlayerItem {
+    /// Binds an item to a media queue.
+    ///
+    /// - Parameters:
+    ///   - currentItem: The current item binding.
+    ///   - mediaQueue: The media queue.
+    func bind(_ currentItem: Binding<CastPlayerItem?>, to mediaQueue: MediaQueue) -> some View {
+        onChange(of: currentItem.wrappedValue) { _ in
+            // TODO: Jump to the item!
+        }
+        .onChange(of: mediaQueue.currentItem) { item in
+            currentItem.wrappedValue = item
+        }
+        .onAppear {
+            currentItem.wrappedValue = mediaQueue.currentItem
+        }
+    }
+}

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -78,6 +78,5 @@ extension MediaQueue: GCKMediaQueueDelegate {
 extension MediaQueue: CastCurrentDelegate {
     func didUpdate(item: CastPlayerItem?) {
         currentItem = item
-        objectWillChange.send()
     }
 }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -10,15 +10,16 @@ import SwiftUI
 /// A queue managing player items.
 public final class MediaQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
+    private let current: CastCurrent
 
     private var cachedItems: [CastCachedPlayerItem] = []
-    private var currentItem: CastPlayerItem?
 
     /// The items in the queue.
     @Published public private(set) var items: [CastPlayerItem] = []
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
+        self.current = .init(remoteMediaClient: remoteMediaClient)
         super.init()
         remoteMediaClient.mediaQueue.add(self)
     }
@@ -34,9 +35,9 @@ public final class MediaQueue: NSObject, ObservableObject {
     /// The current item.
     public func item() -> Binding<CastPlayerItem?> {
         .init { [weak self] in
-            self?.currentItem
+            self?.current.item
         } set: { [weak self] newValue in
-            self?.currentItem = newValue
+            self?.current.item = newValue
         }
     }
 }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-import Combine
 import GoogleCast
 import SwiftUI
 
@@ -12,7 +11,6 @@ import SwiftUI
 public final class MediaQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
     private let current: CastCurrent
-    private var cancellables = Set<AnyCancellable>()
 
     private var cachedItems: [CastCachedPlayerItem] = []
 
@@ -24,13 +22,6 @@ public final class MediaQueue: NSObject, ObservableObject {
         self.current = .init(remoteMediaClient: remoteMediaClient)
         super.init()
         remoteMediaClient.mediaQueue.add(self)
-
-        current.$item
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
     }
 
     /// Load a `CastPlayerItem`.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -35,6 +35,14 @@ public final class MediaQueue: NSObject, ObservableObject {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
         cachedItem.load()
     }
+
+    /// Move to the associated item.
+    ///
+    /// - Parameter item: The item to move to.
+    public func jump(to item: CastPlayerItem) {
+        guard currentItem != item else { return }
+        remoteMediaClient.queueJumpToItem(withID: item.id)
+    }
 }
 
 extension MediaQueue: GCKMediaQueueDelegate {

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -13,10 +13,12 @@ public final class MediaQueue: NSObject, ObservableObject {
     private let current: CastCurrent
 
     private var cachedItems: [CastCachedPlayerItem] = []
-    private var currentItem: CastPlayerItem?
 
     /// The items in the queue.
     @Published public private(set) var items: [CastPlayerItem] = []
+
+    /// The current item.
+    @Published public private(set) var currentItem: CastPlayerItem?
 
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
@@ -32,15 +34,6 @@ public final class MediaQueue: NSObject, ObservableObject {
     public func load(_ item: CastPlayerItem) {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
         cachedItem.load()
-    }
-
-    /// The current item.
-    public func item() -> Binding<CastPlayerItem?> {
-        .init { [weak self] in
-            self?.currentItem
-        } set: { [weak self] newValue in
-            self?.currentItem = newValue
-        }
     }
 }
 

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -12,6 +12,7 @@ public final class MediaQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
 
     private var cachedItems: [CastCachedPlayerItem] = []
+    private var currentItem: CastPlayerItem?
 
     /// The items in the queue.
     @Published public private(set) var items: [CastPlayerItem] = []
@@ -28,6 +29,15 @@ public final class MediaQueue: NSObject, ObservableObject {
     public func load(_ item: CastPlayerItem) {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
         cachedItem.load()
+    }
+
+    /// The current item.
+    public func item() -> Binding<CastPlayerItem?> {
+        .init { [weak self] in
+            self?.currentItem
+        } set: { [weak self] newValue in
+            self?.currentItem = newValue
+        }
     }
 }
 

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -41,7 +41,7 @@ public final class MediaQueue: NSObject, ObservableObject {
     /// - Parameter item: The item to move to.
     public func jump(to item: CastPlayerItem) {
         guard currentItem != item else { return }
-        remoteMediaClient.queueJumpToItem(withID: item.id)
+        current.jump(to: item)
     }
 }
 


### PR DESCRIPTION
## Description

This PR applies a strategy similar to #37 for playlist selection management.

## Hints

The implementation is more convoluted than it should because of how Google Cast item selection and updates work:

- Calling the jump API while a request is still running often breaks the session. For this reason we apply a strategy similar to Pillarbox smooth seeking, waiting for a pending request to finish and executing any pending request afterwards (with always the most recent target id stored).
- When a jump request finishes the media status does not return the reached item yet. It requires a few additional updates until this value is ready. For this reason we only check if the jump final target has been reached in a media status update (resetting the target in the process).
- Cancelling requests is not useful. As documented there is no guarantee that the receiver will cancel anything, only that the sender is not updated.
- Google Cast requests are retained by the framework when in use. For this reason we can store a weak request reference to check whether a request is running or not.

## Changes made

- Implement object to manage the current item (see above hints for details).
- Add list bind modifier to associate an item selection with a media queue.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
