### PR TITLE
Improve playlist item selection

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -173,16 +173,16 @@ private struct MainView: View {
 
 private struct MediaQueueView: View {
     @ObservedObject var mediaQueue: MediaQueue
-    @State private var currentItemId: CastPlayerItem.ID?
+    @State private var selection: CastPlayerItem.ID?
 
     var body: some View {
-        List(mediaQueue.items, selection: $currentItemId) { item in
+        List(mediaQueue.items, selection: $selection) { item in
             MediaQueueCell(item: item)
                 .onAppear {
                     mediaQueue.load(item)
                 }
         }
-        .bind($currentItemId, to: mediaQueue)
+        .bind($selection, to: mediaQueue)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -173,16 +173,16 @@ private struct MainView: View {
 
 private struct MediaQueueView: View {
     @ObservedObject var mediaQueue: MediaQueue
-    @State private var currentItem: CastPlayerItem?
+    @State private var currentItemId: CastPlayerItem.ID?
 
     var body: some View {
-        List(mediaQueue.items, id: \.self, selection: $currentItem) { item in
+        List(mediaQueue.items, selection: $currentItemId) { item in
             MediaQueueCell(item: item)
                 .onAppear {
                     mediaQueue.load(item)
                 }
         }
-        .bind($currentItem, to: mediaQueue)
+        .bind($currentItemId, to: mediaQueue)
     }
 }
 

--- a/Scripts/public/check-quality.sh
+++ b/Scripts/public/check-quality.sh
@@ -41,7 +41,7 @@ fi
 
 echo "... checking Ruby scripts..."
 rm -rf ~/.pkgx/sqlite.org # Avoid https://github.com/pkgxdev/pkgx/issues/1059
-pkgx rubocop --format quiet
+# pkgx rubocop --format quiet # Temporarily deactivated due to the following issue: https://github.com/pkgxdev/pkgx/issues/1150
 
 echo "... checking Shell scripts..."
 shellcheck Scripts/**/*.sh hooks/* Artifacts/**/*.sh

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -25,11 +25,11 @@ final class CastCurrent: NSObject {
         remoteMediaClient.add(self)
     }
 
-    func jump(to item: CastPlayerItem) {
+    func jump(to itemId: CastPlayerItem.ID) {
         if request == nil {
-            request = jumpRequest(to: item.id)
+            request = jumpRequest(to: itemId)
         }
-        pendingRequestItemId = item.id
+        pendingRequestItemId = itemId
     }
 
     private func jumpRequest(to itemID: GCKMediaQueueItemID) -> GCKRequest {

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -7,7 +7,7 @@
 import GoogleCast
 
 /// A cast player item.
-public struct CastPlayerItem: Hashable, Identifiable {
+public struct CastPlayerItem: Identifiable {
     /// The id.
     public let id: GCKMediaQueueItemID
 

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -7,8 +7,10 @@
 import GoogleCast
 
 /// A cast player item.
-public struct CastPlayerItem: Hashable {
-    let id: GCKMediaQueueItemID
+public struct CastPlayerItem: Hashable, Identifiable {
+    /// The id.
+    public let id: GCKMediaQueueItemID
+
     let rawItem: GCKMediaQueueItem?
 
     /// The content title.

--- a/Sources/Castor/Extensions/List.swift
+++ b/Sources/Castor/Extensions/List.swift
@@ -39,8 +39,8 @@ public extension List where SelectionValue == CastPlayerItem.ID {
                 mediaQueue.jump(to: itemId)
             }
         }
-        .onChange(of: mediaQueue.currentItem) { item in
-            currentItemId.wrappedValue = item?.id
+        .onChange(of: mediaQueue.currentItem?.id) { itemId in
+            currentItemId.wrappedValue = itemId
         }
         .onAppear {
             currentItemId.wrappedValue = mediaQueue.currentItem?.id

--- a/Sources/Castor/Extensions/List.swift
+++ b/Sources/Castor/Extensions/List.swift
@@ -27,23 +27,23 @@ public extension List where SelectionValue == CastDevice {
     }
 }
 
-public extension List where SelectionValue == CastPlayerItem {
+public extension List where SelectionValue == CastPlayerItem.ID {
     /// Binds an item to a media queue.
     ///
     /// - Parameters:
-    ///   - currentItem: The current item binding.
+    ///   - currentItemId: The current item id binding.
     ///   - mediaQueue: The media queue.
-    func bind(_ currentItem: Binding<CastPlayerItem?>, to mediaQueue: MediaQueue) -> some View {
-        onChange(of: currentItem.wrappedValue) { item in
-            if let item {
-                mediaQueue.jump(to: item)
+    func bind(_ currentItemId: Binding<SelectionValue?>, to mediaQueue: MediaQueue) -> some View {
+        onChange(of: currentItemId.wrappedValue) { itemId in
+            if let itemId {
+                mediaQueue.jump(to: itemId)
             }
         }
         .onChange(of: mediaQueue.currentItem) { item in
-            currentItem.wrappedValue = item
+            currentItemId.wrappedValue = item?.id
         }
         .onAppear {
-            currentItem.wrappedValue = mediaQueue.currentItem
+            currentItemId.wrappedValue = mediaQueue.currentItem?.id
         }
     }
 }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -38,10 +38,10 @@ public final class MediaQueue: NSObject, ObservableObject {
 
     /// Move to the associated item.
     ///
-    /// - Parameter item: The item to move to.
-    public func jump(to item: CastPlayerItem) {
-        guard currentItem != item else { return }
-        current.jump(to: item)
+    /// - Parameter itemId: The item id to move to.
+    public func jump(to itemId: CastPlayerItem.ID) {
+        guard currentItem?.id != itemId else { return }
+        current.jump(to: itemId)
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes some issues related to the playlist selection:

- Flickering during selection.
- Selecting an item whose `rawItem` is nil (selection ignored).
- Temporary loss of selection when returning to the foreground.

> [!NOTE]
In our playlist, the identification was done via the `currentItem`, but it didn't work very well. 
Indeed, the identity associated to this `currentItem` could change depending on whether the `rawItem` is `nil` or not, which led to undesirable behaviors. By using the **IDs** of the items, this fixes the issues, as the IDs are stable.

## Changes made

- The `CastPlayerItem` has been marked as `Identifiable`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
