### PR TITLE
Make selection APIs more consistent

### DIFF
--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -17,9 +17,4 @@ public struct CastPlayerItem: Identifiable {
     public var title: String? {
         rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
     }
-
-    // swiftlint:disable:next missing_docs
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id && lhs.rawItem?.itemID == rhs.rawItem?.itemID
-    }
 }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -38,8 +38,12 @@ public final class MediaQueue: NSObject, ObservableObject {
 
     /// Move to the associated item.
     ///
-    /// - Parameter itemId: The item id to move to.
-    public func jump(to itemId: CastPlayerItem.ID) {
+    /// - Parameter item: The item to move to.
+    public func jump(to item: CastPlayerItem) {
+        jump(to: item.id)
+    }
+
+    func jump(to itemId: CastPlayerItem.ID) {
         guard currentItem?.id != itemId else { return }
         current.jump(to: itemId)
     }


### PR DESCRIPTION
## Description

This PR slightly adjusts selection APIs to work with player items consistently

## Changes made

- Hide id-based jump API.
- Add item-based jump API.
- Remove `==` operator, following `Hashable` removal in #39.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
