### PR TITLE
Reactivate Ruby linter

### DIFF
--- a/Scripts/public/check-quality.sh
+++ b/Scripts/public/check-quality.sh
@@ -13,7 +13,7 @@ function usage {
 function install_tools {
     curl -Ssf https://pkgx.sh | sh &> /dev/null
     set -a
-    eval "$(pkgx +swiftlint +shellcheck +markdownlint)"
+    eval "$(pkgx +ruby@3.3.6 +swiftlint +shellcheck +markdownlint)" # Temporarily specifying the Ruby version to avoid issues with RuboCop due to the following: https://github.com/pkgxdev/pkgx/issues/1150
     set +a
 }
 
@@ -41,7 +41,7 @@ fi
 
 echo "... checking Ruby scripts..."
 rm -rf ~/.pkgx/sqlite.org # Avoid https://github.com/pkgxdev/pkgx/issues/1059
-# pkgx rubocop --format quiet # Temporarily deactivated due to the following issue: https://github.com/pkgxdev/pkgx/issues/1150
+pkgx rubocop --format quiet
 
 echo "... checking Shell scripts..."
 shellcheck Scripts/**/*.sh hooks/* Artifacts/**/*.sh

--- a/Scripts/public/check-quality.sh
+++ b/Scripts/public/check-quality.sh
@@ -13,7 +13,7 @@ function usage {
 function install_tools {
     curl -Ssf https://pkgx.sh | sh &> /dev/null
     set -a
-    eval "$(pkgx +ruby@3.3.6 +swiftlint +shellcheck +markdownlint)" # Temporarily specifying the Ruby version to avoid issues with RuboCop due to the following: https://github.com/pkgxdev/pkgx/issues/1150
+    eval "$(pkgx +swiftlint +shellcheck +markdownlint)"
     set +a
 }
 


### PR DESCRIPTION
## Description

This PR reactivates RuboCop. The linter was previously deactivated due to an [issue](https://github.com/pkgxdev/pantry/issues/8929).

## Changes made

- Used Ruby version 3.3.6.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
