### PR TITLE
Provide load insertion and deletion APIs

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -195,7 +195,11 @@ private struct MediaQueueView: View {
                 asset: .simple(
                     URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
                 ),
-                metadata: .init(title: "Big Buck Bunny")
+                metadata: .init(
+                    title: "Big Buck Bunny",
+                    // swiftlint:disable:next line_length
+                    imageUrl: URL(string: "https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQ4d816l2_N7O17rr8Cr9nta3z-7--j1ZGGe_9_oqz8zNzjVVPZ4_OdRRMGey-sQssCQBaubQ")!
+                )
             )
         ])
     }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -183,8 +183,13 @@ private struct MediaQueueView: View {
             }
             .bind($selection, to: mediaQueue)
 
-            Button(action: reload) {
-                Text("Reload")
+            HStack {
+                Button(action: reload) {
+                    Text("Reload")
+                }
+                Button(action: insert) {
+                    Text("Insert")
+                }
             }
         }
     }
@@ -201,6 +206,21 @@ private struct MediaQueueView: View {
                 )
             )
         ])
+    }
+
+    private func insert() {
+        mediaQueue.insert(
+            .init(
+                asset: .simple(
+                    URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
+                ),
+                metadata: .init(
+                    title: "Big Buck Bunny",
+                    imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
+                )
+            ),
+            before: nil
+        )
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -179,7 +179,7 @@ private struct MediaQueueView: View {
         List(mediaQueue.items, selection: $selection) { item in
             MediaQueueCell(item: item)
                 .onAppear {
-                    mediaQueue.load(item)
+                    mediaQueue.fetch(item)
                 }
         }
         .bind($selection, to: mediaQueue)

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -192,7 +192,10 @@ private struct MediaQueueView: View {
     private func reload() {
         mediaQueue.load(items: [
             .init(
-                asset: .url(URL(string: "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD")!),
+                asset: .simple(
+                    // swiftlint:disable:next line_length
+                    URL(string: "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD")!
+                ),
                 metadata: .init(title: "The Morning Show")
             )
         ])

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -167,11 +167,11 @@ private struct MainView: View {
     }
 
     private func playlist() -> some View {
-        MediaQueueView(mediaQueue: player.queue)
+        CastQueueView(queue: player.queue)
     }
 }
 
-private struct MediaQueueView: View {
+private struct CastQueueView: View {
     private static let additionalItem = CastPlayerItem(
         asset: .simple(
             URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
@@ -181,17 +181,17 @@ private struct MediaQueueView: View {
             imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
         )
     )
-    @ObservedObject var mediaQueue: MediaQueue
+    @ObservedObject var queue: CastQueue
     @State private var selection: CastPlayerItem.ID?
 
     var body: some View {
         VStack {
-            List(mediaQueue.items, selection: $selection) { item in
-                MediaQueueCell(item: item)
-                    .bind(to: item, from: mediaQueue)
+            List(queue.items, selection: $selection) { item in
+                CastQueueCell(item: item)
+                    .bind(to: item, from: queue)
             }
-            .bind($selection, to: mediaQueue)
-            .animation(.linear, value: mediaQueue.items)
+            .bind($selection, to: queue)
+            .animation(.linear, value: queue.items)
 
             HStack {
                 Button(action: reload) {
@@ -211,24 +211,24 @@ private struct MediaQueueView: View {
     }
 
     private func reload() {
-        mediaQueue.load(items: [Self.additionalItem])
+        queue.load(items: [Self.additionalItem])
     }
 
     private func insert() {
-        mediaQueue.insert([Self.additionalItem], after: mediaQueue.items.last)
+        queue.insert([Self.additionalItem], after: queue.items.last)
     }
 
     private func removeFirst() {
-        if let item = mediaQueue.items.first {
-            mediaQueue.remove([item])
+        if let item = queue.items.first {
+            queue.remove([item])
         }
     }
     private func removeAll() {
-        mediaQueue.removeAllItems()
+        queue.removeAllItems()
     }
 }
 
-private struct MediaQueueCell: View {
+private struct CastQueueCell: View {
     let item: CastPlayerItem
 
     var body: some View {

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -197,8 +197,7 @@ private struct MediaQueueView: View {
                 ),
                 metadata: .init(
                     title: "Big Buck Bunny",
-                    // swiftlint:disable:next line_length
-                    imageUrl: URL(string: "https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQ4d816l2_N7O17rr8Cr9nta3z-7--j1ZGGe_9_oqz8zNzjVVPZ4_OdRRMGey-sQssCQBaubQ")!
+                    imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
                 )
             )
         ])

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -193,10 +193,9 @@ private struct MediaQueueView: View {
         mediaQueue.load(items: [
             .init(
                 asset: .simple(
-                    // swiftlint:disable:next line_length
-                    URL(string: "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD")!
+                    URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
                 ),
-                metadata: .init(title: "The Morning Show")
+                metadata: .init(title: "Big Buck Bunny")
             )
         ])
     }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -178,9 +178,7 @@ private struct MediaQueueView: View {
     var body: some View {
         List(mediaQueue.items, selection: $selection) { item in
             MediaQueueCell(item: item)
-                .onAppear {
-                    mediaQueue.fetch(item)
-                }
+                .bind(to: item, from: mediaQueue)
         }
         .bind($selection, to: mediaQueue)
     }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -172,6 +172,15 @@ private struct MainView: View {
 }
 
 private struct MediaQueueView: View {
+    private static let additionalItem = CastPlayerItem(
+        asset: .simple(
+            URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
+        ),
+        metadata: .init(
+            title: "Big Buck Bunny",
+            imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
+        )
+    )
     @ObservedObject var mediaQueue: MediaQueue
     @State private var selection: CastPlayerItem.ID?
 
@@ -195,34 +204,11 @@ private struct MediaQueueView: View {
     }
 
     private func reload() {
-        mediaQueue.load(items: [
-            .init(
-                asset: .simple(
-                    URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
-                ),
-                metadata: .init(
-                    title: "Big Buck Bunny",
-                    imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
-                )
-            )
-        ])
+        mediaQueue.load(items: [Self.additionalItem])
     }
 
     private func insert() {
-        mediaQueue.insert(
-            [
-                .init(
-                    asset: .simple(
-                        URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
-                    ),
-                    metadata: .init(
-                        title: "Big Buck Bunny",
-                        imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
-                    )
-                )
-            ],
-            after: mediaQueue.items.first
-        )
+        mediaQueue.insert([Self.additionalItem], after: mediaQueue.items.first)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -199,6 +199,9 @@ private struct MediaQueueView: View {
                 Button(action: insert) {
                     Text("Insert")
                 }
+                Button(action: remove) {
+                    Text("Remove")
+                }
             }
         }
     }
@@ -209,6 +212,10 @@ private struct MediaQueueView: View {
 
     private func insert() {
         mediaQueue.insert([Self.additionalItem], after: mediaQueue.items.first)
+    }
+
+    private func remove() {
+        mediaQueue.remove(mediaQueue.items)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -176,11 +176,26 @@ private struct MediaQueueView: View {
     @State private var selection: CastPlayerItem.ID?
 
     var body: some View {
-        List(mediaQueue.items, selection: $selection) { item in
-            MediaQueueCell(item: item)
-                .bind(to: item, from: mediaQueue)
+        VStack {
+            List(mediaQueue.items, selection: $selection) { item in
+                MediaQueueCell(item: item)
+                    .bind(to: item, from: mediaQueue)
+            }
+            .bind($selection, to: mediaQueue)
+
+            Button(action: reload) {
+                Text("Reload")
+            }
         }
-        .bind($selection, to: mediaQueue)
+    }
+
+    private func reload() {
+        mediaQueue.load(items: [
+            .init(
+                asset: .url(URL(string: "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD")!),
+                metadata: .init(title: "The Morning Show")
+            )
+        ])
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -199,8 +199,11 @@ private struct MediaQueueView: View {
                 Button(action: insert) {
                     Text("Insert")
                 }
-                Button(action: remove) {
-                    Text("Remove")
+                Button(action: removeFirst) {
+                    Text("Remove first")
+                }
+                Button(action: removeAll) {
+                    Text("Remove all")
                 }
             }
         }
@@ -211,11 +214,16 @@ private struct MediaQueueView: View {
     }
 
     private func insert() {
-        mediaQueue.insert([Self.additionalItem], after: mediaQueue.items.first)
+        mediaQueue.insert([Self.additionalItem], after: mediaQueue.items.last)
     }
 
-    private func remove() {
-        mediaQueue.remove(mediaQueue.items)
+    private func removeFirst() {
+        if let item = mediaQueue.items.first {
+            mediaQueue.remove([item])
+        }
+    }
+    private func removeAll() {
+        mediaQueue.removeAllItems()
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -191,6 +191,7 @@ private struct MediaQueueView: View {
                     .bind(to: item, from: mediaQueue)
             }
             .bind($selection, to: mediaQueue)
+            .animation(.linear, value: mediaQueue.items)
 
             HStack {
                 Button(action: reload) {

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -210,15 +210,17 @@ private struct MediaQueueView: View {
 
     private func insert() {
         mediaQueue.insert(
-            .init(
-                asset: .simple(
-                    URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
-                ),
-                metadata: .init(
-                    title: "Big Buck Bunny",
-                    imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
+            [
+                .init(
+                    asset: .simple(
+                        URL(string: "https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov")!
+                    ),
+                    metadata: .init(
+                        title: "Big Buck Bunny",
+                        imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
+                    )
                 )
-            ),
+            ],
             after: mediaQueue.items.first
         )
     }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -219,7 +219,7 @@ private struct MediaQueueView: View {
                     imageUrl: URL(string: "https://illudiumfilm.com/big_buck_bunny_title_658w.jpg")!
                 )
             ),
-            before: nil
+            after: mediaQueue.items.first
         )
     }
 }

--- a/Sources/Castor/Asset.swift
+++ b/Sources/Castor/Asset.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+import GoogleCast
+
+public enum Asset {
+    case url(URL)
+    case id(String)
+
+    func mediaInformationBuilder() -> GCKMediaInformationBuilder {
+        switch self {
+        case let .url(url):
+            return GCKMediaInformationBuilder(contentURL: url)
+        case let .id(id):
+            let builder = GCKMediaInformationBuilder()
+            builder.contentID = id
+            return builder
+        }
+    }
+}

--- a/Sources/Castor/Asset.swift
+++ b/Sources/Castor/Asset.swift
@@ -7,15 +7,18 @@
 import Foundation
 import GoogleCast
 
+/// An asset representing content to be played.
 public enum Asset {
-    case url(URL)
-    case id(String)
+    /// Simple assets which can be played directly.
+    case simple(URL)
+    /// Custom assets which require a custom identifier.
+    case custom(String)
 
     func mediaInformationBuilder() -> GCKMediaInformationBuilder {
         switch self {
-        case let .url(url):
+        case let .simple(url):
             return GCKMediaInformationBuilder(contentURL: url)
-        case let .id(id):
+        case let .custom(id):
             let builder = GCKMediaInformationBuilder()
             builder.contentID = id
             return builder

--- a/Sources/Castor/CastAsset.swift
+++ b/Sources/Castor/CastAsset.swift
@@ -7,10 +7,11 @@
 import Foundation
 import GoogleCast
 
-/// An asset representing content to be played.
-public enum Asset {
+/// An cast asset representing content to be played.
+public enum CastAsset {
     /// Simple assets which can be played directly.
     case simple(URL)
+
     /// Custom assets which require a custom identifier.
     case custom(String)
 

--- a/Sources/Castor/CastCachedPlayerItem.swift
+++ b/Sources/Castor/CastCachedPlayerItem.swift
@@ -18,7 +18,7 @@ final class CastCachedPlayerItem: NSObject {
         queue.add(self)
     }
 
-    func load() {
+    func fetch() {
         guard rawItem == nil else { return }
         rawItem = queue.item(withID: id, fetchIfNeeded: false) ?? queue.item(withID: id)
     }

--- a/Sources/Castor/CastMetadata.swift
+++ b/Sources/Castor/CastMetadata.swift
@@ -9,7 +9,7 @@ import GoogleCast
 public struct CastMetadata {
     let rawMetadata: GCKMediaMetadata
 
-    init(title: String?) {
+    public init(title: String?) {
         rawMetadata = GCKMediaMetadata()
         if let title {
             rawMetadata.setString(title, forKey: kGCKMetadataKeyTitle)

--- a/Sources/Castor/CastMetadata.swift
+++ b/Sources/Castor/CastMetadata.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+public struct CastMetadata {
+    let rawMetadata: GCKMediaMetadata
+
+    init(title: String?) {
+        rawMetadata = GCKMediaMetadata()
+        if let title {
+            rawMetadata.setString(title, forKey: kGCKMetadataKeyTitle)
+        }
+    }
+}

--- a/Sources/Castor/CastMetadata.swift
+++ b/Sources/Castor/CastMetadata.swift
@@ -13,10 +13,14 @@ public struct CastMetadata {
     /// Creates metadata.
     ///
     /// - Parameter title: The content title.
-    public init(title: String?) {
+    public init(title: String?, imageUrl: URL?) {
         rawMetadata = GCKMediaMetadata()
         if let title {
             rawMetadata.setString(title, forKey: kGCKMetadataKeyTitle)
+        }
+        if let imageUrl {
+            rawMetadata.removeAllMediaImages()
+            rawMetadata.addImage(.init(url: imageUrl, width: 0, height: 0))
         }
     }
 }

--- a/Sources/Castor/CastMetadata.swift
+++ b/Sources/Castor/CastMetadata.swift
@@ -6,9 +6,13 @@
 
 import GoogleCast
 
+/// Metadata associated to an item.
 public struct CastMetadata {
     let rawMetadata: GCKMediaMetadata
 
+    /// Creates metadata.
+    ///
+    /// - Parameter title: The content title.
     public init(title: String?) {
         rawMetadata = GCKMediaMetadata()
         if let title {

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -16,7 +16,7 @@ public final class CastPlayer: NSObject, ObservableObject {
     @Published private var mediaStatus: GCKMediaStatus?
 
     /// The queue managing player items.
-    public var queue: MediaQueue
+    public var queue: CastQueue
 
     init?(remoteMediaClient: GCKRemoteMediaClient?) {
         guard let remoteMediaClient else { return nil }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -18,12 +18,12 @@ public struct CastPlayerItem: Identifiable, Equatable {
         rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
     }
 
-    /// Creates an item from an asset and a metadata.
+    /// Creates an item from an asset and metadata.
     ///
     /// - Parameters:
     ///   - asset: The asset.
     ///   - metadata: The metadata.
-    public init(asset: Asset, metadata: CastMetadata) {
+    public init(asset: CastAsset, metadata: CastMetadata) {
         self.id = kGCKMediaQueueInvalidItemID
         self.rawItem = Self.rawItem(from: asset, metadata: metadata)
     }
@@ -35,14 +35,14 @@ public struct CastPlayerItem: Identifiable, Equatable {
 }
 
 private extension CastPlayerItem {
-    static func rawItem(from asset: Asset, metadata: CastMetadata) -> GCKMediaQueueItem {
+    static func rawItem(from asset: CastAsset, metadata: CastMetadata) -> GCKMediaQueueItem {
         let builder = GCKMediaQueueItemBuilder()
         builder.mediaInformation = Self.mediaInformation(from: asset, metadata: metadata)
         builder.autoplay = true
         return builder.build()
     }
 
-    static func mediaInformation(from asset: Asset, metadata: CastMetadata) -> GCKMediaInformation {
+    static func mediaInformation(from asset: CastAsset, metadata: CastMetadata) -> GCKMediaInformation {
         let builder = asset.mediaInformationBuilder()
         builder.metadata = metadata.rawMetadata
         return builder.build()

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -7,7 +7,7 @@
 import GoogleCast
 
 /// A cast player item.
-public struct CastPlayerItem: Identifiable {
+public struct CastPlayerItem: Identifiable, Equatable {
     /// The id.
     public let id: GCKMediaQueueItemID
 

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -17,4 +17,26 @@ public struct CastPlayerItem: Identifiable {
     public var title: String? {
         rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
     }
+
+    public init(asset: Asset, metadata: CastMetadata) {
+        self.id = kGCKMediaQueueInvalidItemID
+        self.rawItem = Self.rawItem(from: asset, metadata: metadata)
+    }
+
+    init(id: GCKMediaQueueItemID, rawItem: GCKMediaQueueItem?) {
+        self.id = id
+        self.rawItem = rawItem
+    }
+
+    private static func rawItem(from asset: Asset, metadata: CastMetadata) -> GCKMediaQueueItem {
+        let builder = GCKMediaQueueItemBuilder()
+        builder.mediaInformation = Self.mediaInformation(from: asset, metadata: metadata)
+        return builder.build()
+    }
+
+    private static func mediaInformation(from asset: Asset, metadata: CastMetadata) -> GCKMediaInformation {
+        let builder = asset.mediaInformationBuilder()
+        builder.metadata = metadata.rawMetadata
+        return builder.build()
+    }
 }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -18,6 +18,11 @@ public struct CastPlayerItem: Identifiable {
         rawItem?.mediaInformation.metadata?.string(forKey: kGCKMetadataKeyTitle)
     }
 
+    /// Creates an item from an asset and a metadata.
+    ///
+    /// - Parameters:
+    ///   - asset: The asset.
+    ///   - metadata: The metadata.
     public init(asset: Asset, metadata: CastMetadata) {
         self.id = kGCKMediaQueueInvalidItemID
         self.rawItem = Self.rawItem(from: asset, metadata: metadata)
@@ -27,14 +32,16 @@ public struct CastPlayerItem: Identifiable {
         self.id = id
         self.rawItem = rawItem
     }
+}
 
-    private static func rawItem(from asset: Asset, metadata: CastMetadata) -> GCKMediaQueueItem {
+private extension CastPlayerItem {
+    static func rawItem(from asset: Asset, metadata: CastMetadata) -> GCKMediaQueueItem {
         let builder = GCKMediaQueueItemBuilder()
         builder.mediaInformation = Self.mediaInformation(from: asset, metadata: metadata)
         return builder.build()
     }
 
-    private static func mediaInformation(from asset: Asset, metadata: CastMetadata) -> GCKMediaInformation {
+    static func mediaInformation(from asset: Asset, metadata: CastMetadata) -> GCKMediaInformation {
         let builder = asset.mediaInformationBuilder()
         builder.metadata = metadata.rawMetadata
         return builder.build()

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -38,6 +38,7 @@ private extension CastPlayerItem {
     static func rawItem(from asset: Asset, metadata: CastMetadata) -> GCKMediaQueueItem {
         let builder = GCKMediaQueueItemBuilder()
         builder.mediaInformation = Self.mediaInformation(from: asset, metadata: metadata)
+        builder.autoplay = true
         return builder.build()
     }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -8,7 +8,7 @@ import GoogleCast
 import SwiftUI
 
 /// A queue managing player items.
-public final class MediaQueue: NSObject, ObservableObject {
+public final class CastQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
     private let current: CastCurrent
 
@@ -29,7 +29,7 @@ public final class MediaQueue: NSObject, ObservableObject {
     }
 }
 
-extension MediaQueue: GCKMediaQueueDelegate {
+extension CastQueue: GCKMediaQueueDelegate {
     // swiftlint:disable:next missing_docs
     public func mediaQueueDidReloadItems(_ queue: GCKMediaQueue) {
         cachedItems = (0..<queue.itemCount).map { index in
@@ -59,13 +59,13 @@ extension MediaQueue: GCKMediaQueueDelegate {
     }
 }
 
-extension MediaQueue: CastCurrentDelegate {
+extension CastQueue: CastCurrentDelegate {
     func didUpdate(item: CastPlayerItem?) {
         currentItem = item
     }
 }
 
-extension MediaQueue {
+extension CastQueue {
     func fetch(_ item: CastPlayerItem) {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
         cachedItem.fetch()
@@ -77,8 +77,9 @@ extension MediaQueue {
     }
 }
 
-public extension MediaQueue {
+public extension CastQueue {
     /// Loads player items and starts playback.
+    /// 
     /// - Parameter items: Items to load.
     func load(items: [CastPlayerItem]) {
         remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
@@ -92,7 +93,7 @@ public extension MediaQueue {
     }
 }
 
-public extension MediaQueue {
+public extension CastQueue {
     /// Inserts items before another one.
     ///
     /// - Parameters:
@@ -174,7 +175,7 @@ public extension MediaQueue {
     }
 }
 
-public extension MediaQueue {
+public extension CastQueue {
     /// Removes items from the queue.
     ///
     /// - Parameter items: The items to remove.

--- a/Sources/Castor/Extensions/List.swift
+++ b/Sources/Castor/Extensions/List.swift
@@ -28,22 +28,22 @@ public extension List where SelectionValue == CastDevice {
 }
 
 public extension List where SelectionValue == CastPlayerItem.ID {
-    /// Binds an item to a media queue.
+    /// Binds an item to a queue.
     ///
     /// - Parameters:
     ///   - currentItemId: The current item id binding.
-    ///   - mediaQueue: The media queue.
-    func bind(_ currentItemId: Binding<SelectionValue?>, to mediaQueue: MediaQueue) -> some View {
+    ///   - queue: The queue.
+    func bind(_ currentItemId: Binding<SelectionValue?>, to queue: CastQueue) -> some View {
         onChange(of: currentItemId.wrappedValue) { itemId in
             if let itemId {
-                mediaQueue.jump(to: itemId)
+                queue.jump(to: itemId)
             }
         }
-        .onChange(of: mediaQueue.currentItem?.id) { itemId in
+        .onChange(of: queue.currentItem?.id) { itemId in
             currentItemId.wrappedValue = itemId
         }
         .onAppear {
-            currentItemId.wrappedValue = mediaQueue.currentItem?.id
+            currentItemId.wrappedValue = queue.currentItem?.id
         }
     }
 }

--- a/Sources/Castor/Extensions/View.swift
+++ b/Sources/Castor/Extensions/View.swift
@@ -7,16 +7,16 @@
 import SwiftUI
 
 public extension View {
-    /// Binds to an item from a media queue.
+    /// Binds to an item from a queue.
     ///
     /// - Parameters:
     ///   - item: The item to bind to the view.
-    ///   - mediaQueue: The media queue which fetches the item.
+    ///   - queue: The queue which fetches the item.
     ///
-    /// The item is automatically fetched by the media queue when the view appears.
-    func bind(to item: CastPlayerItem, from mediaQueue: MediaQueue) -> some View {
+    /// The item is automatically fetched by the queue when the view appears.
+    func bind(to item: CastPlayerItem, from queue: CastQueue) -> some View {
         onAppear {
-            mediaQueue.fetch(item)
+            queue.fetch(item)
         }
     }
 }

--- a/Sources/Castor/Extensions/View.swift
+++ b/Sources/Castor/Extensions/View.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+public extension View {
+    /// Binds to an item from a media queue.
+    ///
+    /// - Parameters:
+    ///   - item: The item to bind to the view.
+    ///   - mediaQueue: The media queue which fetches the item.
+    ///
+    /// The item is automatically fetched by the media queue when the view appears.
+    func bind(to item: CastPlayerItem, from mediaQueue: MediaQueue) -> some View {
+        onAppear {
+            mediaQueue.fetch(item)
+        }
+    }
+}

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -107,6 +107,14 @@ public final class MediaQueue: NSObject, ObservableObject {
         insert(items, after: nil)
     }
 
+    /// Removes items from the queue.
+    ///
+    /// - Parameter items: The items to remove.
+    func remove(_ items: [CastPlayerItem]) {
+        // swiftlint:disable:next legacy_objc_type
+        remoteMediaClient.queueRemoveItems(withIDs: items.map { NSNumber(value: $0.id) })
+    }
+
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -34,6 +34,19 @@ public final class MediaQueue: NSObject, ObservableObject {
         remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
     }
 
+    /// Inserts an item before another one.
+    ///
+    /// - Parameters:
+    ///   - item: The item to insert.
+    ///   - beforeItem: The item before which insertion must take place. Pass `nil` to insert the item at the front
+    ///     of the queue.
+    ///
+    /// Does nothing if the item already belongs to the queue.
+    public func insert(_ item: CastPlayerItem, before beforeItem: CastPlayerItem?) {
+        guard let item = item.rawItem else { return }
+        remoteMediaClient.queueInsert([item], beforeItemWithID: beforeItem?.id ?? items.first?.id ?? kGCKMediaQueueInvalidItemID)
+    }
+
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -47,6 +47,29 @@ public final class MediaQueue: NSObject, ObservableObject {
         remoteMediaClient.queueInsert([item], beforeItemWithID: beforeItem?.id ?? items.first?.id ?? kGCKMediaQueueInvalidItemID)
     }
 
+    /// Inserts an item after another one.
+    ///
+    /// - Parameters:
+    ///   - item: The item to insert.
+    ///   - afterItem: The item after which insertion must take place. Pass `nil` to insert the item at the back of
+    ///     the queue. If this item does not exist the method does nothing.
+    /// - Returns: `true` iff the item could be inserted.
+    ///
+    /// Does nothing if the item already belongs to the queue.
+    public func insert(_ item: CastPlayerItem, after afterItem: CastPlayerItem?) {
+        guard let item = item.rawItem else { return }
+        if let afterItemIndex = items.firstIndex(where: { $0.id == afterItem?.id }) {
+            let nextItemIndex = items.index(after: afterItemIndex)
+            if nextItemIndex < items.endIndex {
+                let nextItem = items[nextItemIndex]
+                remoteMediaClient.queueInsert([item], beforeItemWithID: nextItem.id)
+            }
+            else {
+                remoteMediaClient.queueInsert([item], beforeItemWithID: kGCKMediaQueueInvalidItemID)
+            }
+        }
+    }
+
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -67,18 +67,23 @@ public final class MediaQueue: NSObject, ObservableObject {
     /// - Returns: `true` iff the item could be inserted.
     ///
     /// Does nothing if the item already belongs to the queue.
-    public func insert(_ item: CastPlayerItem, after afterItem: CastPlayerItem?) {
-        guard let item = item.rawItem else { return }
-        if let afterItemIndex = items.firstIndex(where: { $0.id == afterItem?.id }) {
+    @discardableResult
+    public func insert(_ item: CastPlayerItem, after afterItem: CastPlayerItem?) -> Bool {
+        guard let item = item.rawItem else { return false }
+        if let afterItem {
+            guard let afterItemIndex = items.firstIndex(where: { $0.id == afterItem.id }) else { return false }
             let nextItemIndex = items.index(after: afterItemIndex)
             if nextItemIndex < items.endIndex {
-                let nextItem = items[nextItemIndex]
-                remoteMediaClient.queueInsert([item], beforeItemWithID: nextItem.id)
+                remoteMediaClient.queueInsert([item], beforeItemWithID: items[nextItemIndex].id)
             }
             else {
                 remoteMediaClient.queueInsert([item], beforeItemWithID: kGCKMediaQueueInvalidItemID)
             }
         }
+        else {
+            remoteMediaClient.queueInsert([item], beforeItemWithID: kGCKMediaQueueInvalidItemID)
+        }
+        return true
     }
 
     /// Move to the associated item.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -28,12 +28,12 @@ public final class MediaQueue: NSObject, ObservableObject {
         remoteMediaClient.mediaQueue.add(self)
     }
 
-    /// Load a `CastPlayerItem`.
+    /// Fetch complete information about a `CastPlayerItem`.
     ///
-    /// - Parameter item: The item to load.
-    public func load(_ item: CastPlayerItem) {
+    /// - Parameter item: The item to fetch.
+    public func fetch(_ item: CastPlayerItem) {
         guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
-        cachedItem.load()
+        cachedItem.fetch()
     }
 
     /// Move to the associated item.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -29,7 +29,7 @@ public final class MediaQueue: NSObject, ObservableObject {
     }
 
     public func load(items: [CastPlayerItem]) {
-        
+        remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
     }
 
     /// Move to the associated item.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -27,7 +27,11 @@ public final class MediaQueue: NSObject, ObservableObject {
         self.current.delegate = self
         remoteMediaClient.mediaQueue.add(self)
     }
-    
+
+    public func load(items: [CastPlayerItem]) {
+        
+    }
+
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -89,6 +89,24 @@ public final class MediaQueue: NSObject, ObservableObject {
         return true
     }
 
+    /// Prepends items to the queue.
+    ///
+    /// - Parameter items: The items to prepend.
+    /// - Returns: `true` iff the items could be prepended.
+    @discardableResult
+    public func prepend(_ items: [CastPlayerItem]) -> Bool {
+        insert(items, before: nil)
+    }
+
+    /// Appends items to the queue.
+    ///
+    /// - Parameter items: The items to append.
+    /// - Returns: `true` iff the items could be appended.
+    @discardableResult
+    public func append(_ items: [CastPlayerItem]) -> Bool {
+        insert(items, after: nil)
+    }
+
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -115,6 +115,11 @@ public final class MediaQueue: NSObject, ObservableObject {
         remoteMediaClient.queueRemoveItems(withIDs: items.map { NSNumber(value: $0.id) })
     }
 
+    /// Removes all items from the queue.
+    public func removeAllItems() {
+        remove(items)
+    }
+
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -27,20 +27,17 @@ public final class MediaQueue: NSObject, ObservableObject {
         self.current.delegate = self
         remoteMediaClient.mediaQueue.add(self)
     }
-
-    /// Fetch complete information about a `CastPlayerItem`.
-    ///
-    /// - Parameter item: The item to fetch.
-    public func fetch(_ item: CastPlayerItem) {
-        guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
-        cachedItem.fetch()
-    }
-
+    
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.
     public func jump(to item: CastPlayerItem) {
         jump(to: item.id)
+    }
+
+    func fetch(_ item: CastPlayerItem) {
+        guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
+        cachedItem.fetch()
     }
 
     func jump(to itemId: CastPlayerItem.ID) {

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -28,6 +28,8 @@ public final class MediaQueue: NSObject, ObservableObject {
         remoteMediaClient.mediaQueue.add(self)
     }
 
+    /// Loads player items and starts playback.
+    /// - Parameter items: Items to load.
     public func load(items: [CastPlayerItem]) {
         remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
     }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -65,6 +65,18 @@ extension MediaQueue: CastCurrentDelegate {
     }
 }
 
+extension MediaQueue {
+    func fetch(_ item: CastPlayerItem) {
+        guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
+        cachedItem.fetch()
+    }
+
+    func jump(to itemId: CastPlayerItem.ID) {
+        guard currentItem?.id != itemId else { return }
+        current.jump(to: itemId)
+    }
+}
+
 public extension MediaQueue {
     /// Loads player items and starts playback.
     /// - Parameter items: Items to load.
@@ -72,23 +84,11 @@ public extension MediaQueue {
         remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
     }
 
-    internal func fetch(_ item: CastPlayerItem) {
-        guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
-        cachedItem.fetch()
-    }
-}
-
-public extension MediaQueue {
     /// Move to the associated item.
     ///
     /// - Parameter item: The item to move to.
     func jump(to item: CastPlayerItem) {
         jump(to: item.id)
-    }
-
-    internal func jump(to itemId: CastPlayerItem.ID) {
-        guard currentItem?.id != itemId else { return }
-        current.jump(to: itemId)
     }
 }
 

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -42,9 +42,20 @@ public final class MediaQueue: NSObject, ObservableObject {
     ///     of the queue.
     ///
     /// Does nothing if the item already belongs to the queue.
-    public func insert(_ item: CastPlayerItem, before beforeItem: CastPlayerItem?) {
-        guard let item = item.rawItem else { return }
-        remoteMediaClient.queueInsert([item], beforeItemWithID: beforeItem?.id ?? items.first?.id ?? kGCKMediaQueueInvalidItemID)
+    @discardableResult
+    public func insert(_ item: CastPlayerItem, before beforeItem: CastPlayerItem?) -> Bool {
+        guard let item = item.rawItem else { return false }
+        if let beforeItem {
+            guard items.contains(where: { $0.id == beforeItem.id }) else { return false }
+            remoteMediaClient.queueInsert([item], beforeItemWithID: beforeItem.id)
+        }
+        else if let firstItem = items.first {
+            remoteMediaClient.queueInsert([item], beforeItemWithID: firstItem.id)
+        }
+        else {
+            remoteMediaClient.queueInsert([item], beforeItemWithID: kGCKMediaQueueInvalidItemID)
+        }
+        return true
     }
 
     /// Inserts an item after another one.

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -110,7 +110,7 @@ public final class MediaQueue: NSObject, ObservableObject {
     /// Removes items from the queue.
     ///
     /// - Parameter items: The items to remove.
-    func remove(_ items: [CastPlayerItem]) {
+    public func remove(_ items: [CastPlayerItem]) {
         // swiftlint:disable:next legacy_objc_type
         remoteMediaClient.queueRemoveItems(withIDs: items.map { NSNumber(value: $0.id) })
     }

--- a/Sources/Castor/MediaQueue.swift
+++ b/Sources/Castor/MediaQueue.swift
@@ -27,122 +27,6 @@ public final class MediaQueue: NSObject, ObservableObject {
         self.current.delegate = self
         remoteMediaClient.mediaQueue.add(self)
     }
-
-    /// Loads player items and starts playback.
-    /// - Parameter items: Items to load.
-    public func load(items: [CastPlayerItem]) {
-        remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
-    }
-
-    /// Inserts items before another one.
-    ///
-    /// - Parameters:
-    ///   - insertedItems: The items to insert.
-    ///   - beforeItem: The item before which insertion must take place. Pass `nil` to insert the items at the front
-    ///     of the queue.
-    /// - Returns: `true` iff some items could be inserted.
-    ///
-    /// Ignores items already belonging to the queue.
-    @discardableResult
-    public func insert(_ insertedItems: [CastPlayerItem], before beforeItem: CastPlayerItem?) -> Bool {
-        let rawItems = insertableRawItem(from: insertedItems)
-        guard !rawItems.isEmpty else { return false }
-        if let beforeItem {
-            guard items.contains(where: { $0.id == beforeItem.id }) else { return false }
-            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: beforeItem.id)
-        }
-        else if let firstItem = items.first {
-            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: firstItem.id)
-        }
-        else {
-            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: kGCKMediaQueueInvalidItemID)
-        }
-        return true
-    }
-
-    /// Inserts items after another one.
-    ///
-    /// - Parameters:
-    ///   - insertedItems: The items to insert.
-    ///   - afterItem: The item after which insertion must take place. Pass `nil` to insert the items at the back of
-    ///     the queue. If this item does not exist the method does nothing.
-    /// - Returns: `true` iff some items could be inserted.
-    ///
-    /// Ignores items already belonging to the queue.
-    @discardableResult
-    public func insert(_ insertedItems: [CastPlayerItem], after afterItem: CastPlayerItem?) -> Bool {
-        let rawItems = insertableRawItem(from: insertedItems)
-        guard !rawItems.isEmpty else { return false }
-        if let afterItem {
-            guard let afterItemIndex = items.firstIndex(where: { $0.id == afterItem.id }) else { return false }
-            let nextItemIndex = items.index(after: afterItemIndex)
-            if nextItemIndex < items.endIndex {
-                remoteMediaClient.queueInsert(rawItems, beforeItemWithID: items[nextItemIndex].id)
-            }
-            else {
-                remoteMediaClient.queueInsert(rawItems, beforeItemWithID: kGCKMediaQueueInvalidItemID)
-            }
-        }
-        else {
-            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: kGCKMediaQueueInvalidItemID)
-        }
-        return true
-    }
-
-    /// Prepends items to the queue.
-    ///
-    /// - Parameter items: The items to prepend.
-    /// - Returns: `true` iff the items could be prepended.
-    @discardableResult
-    public func prepend(_ items: [CastPlayerItem]) -> Bool {
-        insert(items, before: nil)
-    }
-
-    /// Appends items to the queue.
-    ///
-    /// - Parameter items: The items to append.
-    /// - Returns: `true` iff the items could be appended.
-    @discardableResult
-    public func append(_ items: [CastPlayerItem]) -> Bool {
-        insert(items, after: nil)
-    }
-
-    /// Removes items from the queue.
-    ///
-    /// - Parameter items: The items to remove.
-    public func remove(_ items: [CastPlayerItem]) {
-        // swiftlint:disable:next legacy_objc_type
-        remoteMediaClient.queueRemoveItems(withIDs: items.map { NSNumber(value: $0.id) })
-    }
-
-    /// Removes all items from the queue.
-    public func removeAllItems() {
-        remove(items)
-    }
-
-    /// Move to the associated item.
-    ///
-    /// - Parameter item: The item to move to.
-    public func jump(to item: CastPlayerItem) {
-        jump(to: item.id)
-    }
-
-    func fetch(_ item: CastPlayerItem) {
-        guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
-        cachedItem.fetch()
-    }
-
-    func jump(to itemId: CastPlayerItem.ID) {
-        guard currentItem?.id != itemId else { return }
-        current.jump(to: itemId)
-    }
-
-    private func insertableRawItem(from items: [CastPlayerItem]) -> [GCKMediaQueueItem] {
-        items.filter { item in
-            !self.items.contains { $0.id == item.id }
-        }
-        .compactMap(\.rawItem)
-    }
 }
 
 extension MediaQueue: GCKMediaQueueDelegate {
@@ -178,5 +62,129 @@ extension MediaQueue: GCKMediaQueueDelegate {
 extension MediaQueue: CastCurrentDelegate {
     func didUpdate(item: CastPlayerItem?) {
         currentItem = item
+    }
+}
+
+public extension MediaQueue {
+    /// Loads player items and starts playback.
+    /// - Parameter items: Items to load.
+    func load(items: [CastPlayerItem]) {
+        remoteMediaClient.queueLoad(items.compactMap(\.rawItem), with: .init())
+    }
+
+    internal func fetch(_ item: CastPlayerItem) {
+        guard let cachedItem = cachedItems.first(where: { $0.id == item.id }) else { return }
+        cachedItem.fetch()
+    }
+}
+
+public extension MediaQueue {
+    /// Move to the associated item.
+    ///
+    /// - Parameter item: The item to move to.
+    func jump(to item: CastPlayerItem) {
+        jump(to: item.id)
+    }
+
+    internal func jump(to itemId: CastPlayerItem.ID) {
+        guard currentItem?.id != itemId else { return }
+        current.jump(to: itemId)
+    }
+}
+
+public extension MediaQueue {
+    /// Inserts items before another one.
+    ///
+    /// - Parameters:
+    ///   - insertedItems: The items to insert.
+    ///   - beforeItem: The item before which insertion must take place. Pass `nil` to insert the items at the front
+    ///     of the queue.
+    /// - Returns: `true` iff some items could be inserted.
+    ///
+    /// Ignores items already belonging to the queue.
+    @discardableResult
+    func insert(_ insertedItems: [CastPlayerItem], before beforeItem: CastPlayerItem?) -> Bool {
+        let rawItems = insertableRawItem(from: insertedItems)
+        guard !rawItems.isEmpty else { return false }
+        if let beforeItem {
+            guard items.contains(where: { $0.id == beforeItem.id }) else { return false }
+            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: beforeItem.id)
+        }
+        else if let firstItem = items.first {
+            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: firstItem.id)
+        }
+        else {
+            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: kGCKMediaQueueInvalidItemID)
+        }
+        return true
+    }
+
+    /// Inserts items after another one.
+    ///
+    /// - Parameters:
+    ///   - insertedItems: The items to insert.
+    ///   - afterItem: The item after which insertion must take place. Pass `nil` to insert the items at the back of
+    ///     the queue. If this item does not exist the method does nothing.
+    /// - Returns: `true` iff some items could be inserted.
+    ///
+    /// Ignores items already belonging to the queue.
+    @discardableResult
+    func insert(_ insertedItems: [CastPlayerItem], after afterItem: CastPlayerItem?) -> Bool {
+        let rawItems = insertableRawItem(from: insertedItems)
+        guard !rawItems.isEmpty else { return false }
+        if let afterItem {
+            guard let afterItemIndex = items.firstIndex(where: { $0.id == afterItem.id }) else { return false }
+            let nextItemIndex = items.index(after: afterItemIndex)
+            if nextItemIndex < items.endIndex {
+                remoteMediaClient.queueInsert(rawItems, beforeItemWithID: items[nextItemIndex].id)
+            }
+            else {
+                remoteMediaClient.queueInsert(rawItems, beforeItemWithID: kGCKMediaQueueInvalidItemID)
+            }
+        }
+        else {
+            remoteMediaClient.queueInsert(rawItems, beforeItemWithID: kGCKMediaQueueInvalidItemID)
+        }
+        return true
+    }
+
+    /// Prepends items to the queue.
+    ///
+    /// - Parameter items: The items to prepend.
+    /// - Returns: `true` iff the items could be prepended.
+    @discardableResult
+    func prepend(_ items: [CastPlayerItem]) -> Bool {
+        insert(items, before: nil)
+    }
+
+    /// Appends items to the queue.
+    ///
+    /// - Parameter items: The items to append.
+    /// - Returns: `true` iff the items could be appended.
+    @discardableResult
+    func append(_ items: [CastPlayerItem]) -> Bool {
+        insert(items, after: nil)
+    }
+
+    private func insertableRawItem(from items: [CastPlayerItem]) -> [GCKMediaQueueItem] {
+        items.filter { item in
+            !self.items.contains { $0.id == item.id }
+        }
+        .compactMap(\.rawItem)
+    }
+}
+
+public extension MediaQueue {
+    /// Removes items from the queue.
+    ///
+    /// - Parameter items: The items to remove.
+    func remove(_ items: [CastPlayerItem]) {
+        // swiftlint:disable:next legacy_objc_type
+        remoteMediaClient.queueRemoveItems(withIDs: items.map { NSNumber(value: $0.id) })
+    }
+
+    /// Removes all items from the queue.
+    func removeAllItems() {
+        remove(items)
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a set of APIs for managing element insertion and deletion.

## Changes made

- The enum `CastAsset` has been introduced with simple and custom cases.
- The `MediaQueue` has been renamed to `CastQueue`.
- A method `load` on the `CastQueue` has been added to load one or several `CastPlayerItem`.
- `CastPlayerItem` has been marked as `Equatable` to be able to animate the playlist.
- `CastMetadata` has been introduced to provide metadata to a player item.
- Numerous APIs for managing insertion and deletions have been added.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
