### PR TITLE
Support current item selection and playlist navigation

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -177,7 +177,7 @@ private struct CastQueueView: View {
     var body: some View {
         VStack(spacing: 0) {
             toolbar()
-            List($queue.items, id: \.self, editActions: .all) { item in
+            List($queue.items, id: \.self, editActions: .all, selection: $queue.currentItem) { item in
                 CastQueueCell(item: item.wrappedValue)
             }
             .animation(.linear, value: queue.items)

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -177,7 +177,7 @@ private struct CastQueueView: View {
     var body: some View {
         VStack(spacing: 0) {
             toolbar()
-            List($queue.items, id: \.self, editActions: .all, selection: $queue.currentItem) { item in
+            List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { item in
                 CastQueueCell(item: item.wrappedValue)
             }
             .animation(.linear, value: queue.items)

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -177,11 +177,24 @@ private struct CastQueueView: View {
     var body: some View {
         VStack(spacing: 0) {
             toolbar()
-            List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { item in
-                CastQueueCell(item: item.wrappedValue)
-            }
-            .animation(.linear, value: queue.items)
+            list()
         }
+    }
+
+    private func list() -> some View {
+        ZStack {
+            if !queue.items.isEmpty {
+                List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { item in
+                    CastQueueCell(item: item.wrappedValue)
+                }
+            }
+            else {
+                ContentUnavailableView {
+                    Text("No items")
+                }
+            }
+        }
+        .animation(.linear, value: queue.items)
     }
 
     private func toolbar() -> some View {

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -185,6 +185,24 @@ private struct CastQueueView: View {
     }
 
     private func toolbar() -> some View {
+        HStack {
+            previousButton()
+            Spacer()
+            managementButtons()
+            Spacer()
+            nextButton()
+        }
+        .padding()
+    }
+
+    private func previousButton() -> some View {
+        Button(action: queue.returnToPreviousItem) {
+            Image(systemName: "arrow.left")
+        }
+        .disabled(!queue.canReturnToPreviousItem())
+    }
+
+    private func managementButtons() -> some View {
         HStack(spacing: 30) {
             Button(action: shuffle) {
                 Image(systemName: "shuffle")
@@ -197,6 +215,13 @@ private struct CastQueueView: View {
             .disabled(queue.isEmpty)
         }
         .padding()
+    }
+
+    private func nextButton() -> some View {
+        Button(action: queue.advanceToNextItem) {
+            Image(systemName: "arrow.right")
+        }
+        .disabled(!queue.canAdvanceToNextItem())
     }
 
     private func shuffle() {

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -26,7 +26,7 @@ public final class Cast: NSObject, ObservableObject {
     /// Ends the session if set to `nil`.
     ///
     /// > Important: On iOS 18.3 and below use `currentDeviceSelection` to manage selection in a `List`.
-    @Published public var currentDevice: CastDevice? {
+    public var currentDevice: CastDevice? {
         didSet {
             if let currentDevice {
                 moveSession(from: oldValue, to: currentDevice)
@@ -34,6 +34,16 @@ public final class Cast: NSObject, ObservableObject {
             else {
                 endSession()
             }
+        }
+    }
+
+    private var publishedCurrentDevice: CastDevice? {
+        get {
+            currentDevice
+        }
+        set {
+            currentDevice = newValue
+            objectWillChange.send()
         }
     }
 
@@ -122,7 +132,7 @@ extension Cast: GCKSessionManagerListener {
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, willStart session: GCKCastSession) {
         currentSession = session
-        currentDevice = session.device.toCastDevice()
+        publishedCurrentDevice = session.device.toCastDevice()
     }
 
     // swiftlint:disable:next missing_docs
@@ -152,7 +162,7 @@ extension Cast: GCKSessionManagerListener {
             self.targetDevice = nil
         }
         else {
-            currentDevice = nil
+            publishedCurrentDevice = nil
         }
     }
 
@@ -163,7 +173,7 @@ extension Cast: GCKSessionManagerListener {
         withError error: any Error
     ) {
         currentSession = nil
-        currentDevice = nil
+        publishedCurrentDevice = nil
     }
 }
 

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -44,7 +44,9 @@ extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
         if let mediaStatus {
             if let pendingRequestItemId {
-                if mediaStatus.currentItemID == pendingRequestItemId {
+                let isPendingItemReached = mediaStatus.currentItemID == pendingRequestItemId
+                let isPendingItemMissing = client.mediaQueue.indexOfItem(withID: pendingRequestItemId) == NSNotFound
+                if isPendingItemReached || isPendingItemMissing {
                     delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
                     self.pendingRequestItemId = nil
                 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -42,15 +42,19 @@ final class CastCurrent: NSObject {
 
 extension CastCurrent: GCKRemoteMediaClientListener {
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        guard let mediaStatus else { return }
-        if let pendingRequestItemId {
-            if mediaStatus.currentItemID == pendingRequestItemId {
+        if let mediaStatus {
+            if let pendingRequestItemId {
+                if mediaStatus.currentItemID == pendingRequestItemId {
+                    delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
+                    self.pendingRequestItemId = nil
+                }
+            }
+            else {
                 delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
-                self.pendingRequestItemId = nil
             }
         }
         else {
-            delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
+            delegate?.didUpdate(item: nil)
         }
     }
 }

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -1,0 +1,63 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+protocol CastCurrentDelegate: AnyObject {
+    func didUpdate(item: CastPlayerItem?)
+}
+
+final class CastCurrent: NSObject {
+    private let remoteMediaClient: GCKRemoteMediaClient
+
+    private weak var request: GCKRequest?
+    private var requestItemId: GCKMediaQueueItemID?
+    private var pendingRequestItemId: GCKMediaQueueItemID?
+
+    weak var delegate: CastCurrentDelegate?
+
+    init(remoteMediaClient: GCKRemoteMediaClient) {
+        self.remoteMediaClient = remoteMediaClient
+        super.init()
+        remoteMediaClient.add(self)
+    }
+
+    func jump(to itemId: GCKMediaQueueItemID) {
+        if request == nil {
+            request = jumpRequest(to: itemId)
+        }
+        pendingRequestItemId = itemId
+    }
+
+    private func jumpRequest(to itemID: GCKMediaQueueItemID) -> GCKRequest {
+        let request = remoteMediaClient.queueJumpToItem(withID: itemID)
+        request.delegate = self
+        requestItemId = itemID
+        return request
+    }
+}
+
+extension CastCurrent: GCKRemoteMediaClientListener {
+    func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
+        guard let mediaStatus else { return }
+        if let pendingRequestItemId {
+            if mediaStatus.currentItemID == pendingRequestItemId {
+                delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
+                self.pendingRequestItemId = nil
+            }
+        }
+        else {
+            delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
+        }
+    }
+}
+
+extension CastCurrent: GCKRequestDelegate {
+    func requestDidComplete(_ request: GCKRequest) {
+        guard let pendingRequestItemId, pendingRequestItemId != requestItemId else { return }
+        self.request = jumpRequest(to: pendingRequestItemId)
+    }
+}

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -10,6 +10,8 @@ protocol CastCurrentDelegate: AnyObject {
     func didUpdate(item: CastPlayerItem?)
 }
 
+/// This class is a workaround to avoid cast session instabilities when jumps are performed in quick succession.
+/// It should ideally be removed if jumps are made reliable at the Google Cast SDK level directly.
 final class CastCurrent: NSObject {
     private let remoteMediaClient: GCKRemoteMediaClient
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -146,6 +146,34 @@ public extension CastQueue {
     }
 }
 
+public extension CastQueue {
+    /// Checks whether returning to the previous item in the queue is possible.
+    ///
+    /// - Returns: `true` if possible.
+    func canReturnToPreviousItem() -> Bool {
+        !items.isEmpty && currentItem?.id != items.first?.id
+    }
+
+    /// Returns to the previous item in the queue.
+    func returnToPreviousItem() {
+        guard canReturnToPreviousItem(), let currentItem, let previousIndex = Self.index(before: currentItem, in: items) else { return }
+        current.jump(to: items[previousIndex].id)
+    }
+
+    /// Checks whether moving to the next item in the queue is possible.
+    ///
+    /// - Returns: `true` if possible.
+    func canAdvanceToNextItem() -> Bool {
+        !items.isEmpty && currentItem?.id != items.last?.id
+    }
+
+    /// Moves to the next item in the queue.
+    func advanceToNextItem() {
+        guard canAdvanceToNextItem(), let currentItem, let nextIndex = Self.index(after: currentItem, in: items) else { return }
+        current.jump(to: items[nextIndex].id)
+    }
+}
+
 private extension CastQueue {
     func canMove(_ item: CastPlayerItem, before beforeItem: CastPlayerItem?) -> Bool {
         guard items.contains(item) else { return false }
@@ -169,6 +197,21 @@ private extension CastQueue {
         else {
             return items.last != item
         }
+    }
+}
+
+private extension CastQueue {
+    static func index(after item: CastPlayerItem, in items: [CastPlayerItem]) -> Int? {
+        guard let itemIndex = items.firstIndex(of: item) else { return nil }
+        let nextIndex = items.index(after: itemIndex)
+        return (nextIndex < items.endIndex) ? nextIndex : nil
+    }
+
+    static func index(before item: CastPlayerItem, in items: [CastPlayerItem]) -> Int? {
+        guard let itemIndex = items.firstIndex(of: item), itemIndex > items.startIndex else {
+            return nil
+        }
+        return items.index(before: itemIndex)
     }
 }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -24,7 +24,7 @@ public final class CastQueue: NSObject, ObservableObject {
     /// Stops playback if set to `nil`.
     ///
     /// > Important: On iOS 18.3 and below use `currentItemSelection` to manage selection in a `List`.
-    @Published public var currentItem: CastPlayerItem? {
+    public var currentItem: CastPlayerItem? {
         didSet {
             if let currentItem {
                 guard currentItem != oldValue else { return }
@@ -249,6 +249,7 @@ private extension CastQueue {
 extension CastQueue: CastCurrentDelegate {
     func didUpdate(item: CastPlayerItem?) {
         currentItem = item
+        objectWillChange.send()
     }
 }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -36,6 +36,16 @@ public final class CastQueue: NSObject, ObservableObject {
         }
     }
 
+    private var publishedCurrentItem: CastPlayerItem? {
+        get {
+            currentItem
+        }
+        set {
+            currentItem = newValue
+            objectWillChange.send()
+        }
+    }
+
     /// A binding to the current item, for use as `List` selection.
     @available(iOS, introduced: 16.0, deprecated: 18.4, message: "Use currentItem instead")
     public var currentItemSelection: Binding<CastPlayerItem?> {
@@ -248,8 +258,7 @@ private extension CastQueue {
 
 extension CastQueue: CastCurrentDelegate {
     func didUpdate(item: CastPlayerItem?) {
-        currentItem = item
-        objectWillChange.send()
+        publishedCurrentItem = item
     }
 }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -19,6 +19,9 @@ public final class CastQueue: NSObject, ObservableObject {
         }
     }
 
+    /// The current item.
+    @Published public var currentItem: CastPlayerItem?
+
     private var canRequest = true
 
     private var nonRequestedItems: [CastPlayerItem] {

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -20,6 +20,10 @@ public final class CastQueue: NSObject, ObservableObject {
     }
 
     /// The current item.
+    ///
+    /// Stops playback if set to `nil`.
+    ///
+    /// > Important: On iOS 18.3 and below use `currentItemSelection` to manage selection in a `List`.
     @Published public var currentItem: CastPlayerItem? {
         didSet {
             if let currentItem {
@@ -29,6 +33,17 @@ public final class CastQueue: NSObject, ObservableObject {
             else {
                 remoteMediaClient.stop()
             }
+        }
+    }
+
+    /// A binding to the current item, for use as `List` selection.
+    @available(iOS, introduced: 16.0, deprecated: 18.4, message: "Use currentItem instead")
+    public var currentItemSelection: Binding<CastPlayerItem?> {
+        .init { [weak self] in
+            self?.currentItem
+        } set: { [weak self] item in
+            guard let self, let item else { return }
+            currentItem = item
         }
     }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -157,7 +157,7 @@ public extension CastQueue {
     /// Returns to the previous item in the queue.
     func returnToPreviousItem() {
         guard canReturnToPreviousItem(), let currentItem, let previousIndex = Self.index(before: currentItem, in: items) else { return }
-        current.jump(to: items[previousIndex].id)
+        self.currentItem = items[previousIndex]
     }
 
     /// Checks whether moving to the next item in the queue is possible.
@@ -170,7 +170,7 @@ public extension CastQueue {
     /// Moves to the next item in the queue.
     func advanceToNextItem() {
         guard canAdvanceToNextItem(), let currentItem, let nextIndex = Self.index(after: currentItem, in: items) else { return }
-        current.jump(to: items[nextIndex].id)
+        self.currentItem = items[nextIndex]
     }
 }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -167,7 +167,7 @@ public extension CastQueue {
     /// Returns to the previous item in the queue.
     func returnToPreviousItem() {
         guard canReturnToPreviousItem(), let currentItem, let previousIndex = Self.index(before: currentItem, in: items) else { return }
-        self.currentItem = items[previousIndex]
+        publishedCurrentItem = items[previousIndex]
     }
 
     /// Checks whether moving to the next item in the queue is possible.
@@ -180,7 +180,7 @@ public extension CastQueue {
     /// Moves to the next item in the queue.
     func advanceToNextItem() {
         guard canAdvanceToNextItem(), let currentItem, let nextIndex = Self.index(after: currentItem, in: items) else { return }
-        self.currentItem = items[nextIndex]
+        publishedCurrentItem = items[nextIndex]
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds support for current item selection in a playlist, as well as APIs to navigate it. Unlike Pillarbox we currently only provide raw item-based navigation APIs without smart behaviors.

## Changes made

- Add `currentItem` property and associated binding for list selection on iOS 18.3 and below.
- Add navigation APIs.
- Add playlist navigation buttons in the demo.
- Introduce workaround for session instabilities created by successive jumps.
- Fix incorrect view updates triggered when updating devices in a list.

### Remark

We have mitigated issues with successive direct jumps but the same issue arises when deleting the current item in sequence. This issue will not be mitigated for the moment as it is far less annoying.

We also cannot avoid issues if several senders change the current item concurrently.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
