### PR TITLE
Fix sync between sender and receiver

### DIFF
--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -34,16 +34,9 @@ public final class Cast: NSObject, ObservableObject {
             else {
                 endSession()
             }
-        }
-    }
-
-    private var publishedCurrentDevice: CastDevice? {
-        get {
-            currentDevice
-        }
-        set {
-            currentDevice = newValue
-            objectWillChange.send()
+            DispatchQueue.main.async {
+                self.objectWillChange.send()
+            }
         }
     }
 
@@ -132,7 +125,7 @@ extension Cast: GCKSessionManagerListener {
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, willStart session: GCKCastSession) {
         currentSession = session
-        publishedCurrentDevice = session.device.toCastDevice()
+        currentDevice = session.device.toCastDevice()
     }
 
     // swiftlint:disable:next missing_docs
@@ -162,7 +155,7 @@ extension Cast: GCKSessionManagerListener {
             self.targetDevice = nil
         }
         else {
-            publishedCurrentDevice = nil
+            currentDevice = nil
         }
     }
 
@@ -173,7 +166,7 @@ extension Cast: GCKSessionManagerListener {
         withError error: any Error
     ) {
         currentSession = nil
-        publishedCurrentDevice = nil
+        currentDevice = nil
     }
 }
 

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -28,6 +28,7 @@ final class CastCurrent: NSObject {
     }
 
     func jump(to itemId: GCKMediaQueueItemID) {
+        guard remoteMediaClient.mediaStatus?.currentItemID != itemId else { return }
         if request == nil {
             request = jumpRequest(to: itemId)
         }

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -236,6 +236,13 @@ private extension CastQueue {
     }
 
     func requestUpdates(from previousItems: [CastPlayerItem], to currentItems: [CastPlayerItem]) {
+        // Workaround for Google Cast SDK issue. If emptying a playlist with as many removal requests as needed,
+        // and if the playlist is being mutated from another sender at the same time, one request might never end.
+        guard !currentItems.isEmpty else {
+            remoteMediaClient.stop()
+            return
+        }
+
         let mutations = Mutation.mutations(from: previousItems, to: currentItems)
         requests += mutations.count
         mutations.forEach { mutation in

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -236,17 +236,20 @@ private extension CastQueue {
         let mutations = Mutation.mutations(from: previousItems, to: currentItems)
         requests += mutations.count
         mutations.forEach { mutation in
-            switch mutation {
-            case let .move(element, before):
-                let request = remoteMediaClient.queueMoveItem(
-                    withID: element.id,
-                    beforeItemWithID: before?.id ?? kGCKMediaQueueInvalidItemID
-                )
-                request.delegate = self
-            case let .remove(element):
-                let request = remoteMediaClient.queueRemoveItem(withID: element.id)
-                request.delegate = self
-            }
+            let request = request(for: mutation)
+            request.delegate = self
+        }
+    }
+
+    private func request(for mutation: Mutation<CastPlayerItem>) -> GCKRequest {
+        switch mutation {
+        case let .move(element, before):
+            remoteMediaClient.queueMoveItem(
+                withID: element.id,
+                beforeItemWithID: before?.id ?? kGCKMediaQueueInvalidItemID
+            )
+        case let .remove(element):
+            remoteMediaClient.queueRemoveItem(withID: element.id)
         }
     }
 }

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -36,16 +36,9 @@ public final class CastQueue: NSObject, ObservableObject {
             else {
                 remoteMediaClient.stop()
             }
-        }
-    }
-
-    private var publishedCurrentItem: CastPlayerItem? {
-        get {
-            currentItem
-        }
-        set {
-            currentItem = newValue
-            objectWillChange.send()
+            DispatchQueue.main.async {
+                self.objectWillChange.send()
+            }
         }
     }
 
@@ -170,7 +163,7 @@ public extension CastQueue {
     /// Returns to the previous item in the queue.
     func returnToPreviousItem() {
         guard canReturnToPreviousItem(), let currentItem, let previousIndex = Self.index(before: currentItem, in: items) else { return }
-        publishedCurrentItem = items[previousIndex]
+        self.currentItem = items[previousIndex]
     }
 
     /// Checks whether moving to the next item in the queue is possible.
@@ -183,7 +176,7 @@ public extension CastQueue {
     /// Moves to the next item in the queue.
     func advanceToNextItem() {
         guard canAdvanceToNextItem(), let currentItem, let nextIndex = Self.index(after: currentItem, in: items) else { return }
-        publishedCurrentItem = items[nextIndex]
+        self.currentItem = items[nextIndex]
     }
 }
 
@@ -266,7 +259,7 @@ private extension CastQueue {
 
 extension CastQueue: CastCurrentDelegate {
     func didUpdate(item: CastPlayerItem?) {
-        publishedCurrentItem = item
+        currentItem = item
     }
 }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -12,6 +12,9 @@ public final class CastQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
 
     /// The items in the queue.
+    ///
+    /// > Warning: Avoid making significant changes to the item list by mutating this property, as each change will
+    ///   be performed asynchronously on the receiver.
     @Published public var items: [CastPlayerItem] = [] {
         didSet {
             guard canRequest else { return }

--- a/Sources/Castor/Extensions/Collection.swift
+++ b/Sources/Castor/Extensions/Collection.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+extension Collection {
+    /// Safely returns the item at the specified index.
+    /// 
+    /// - Parameter index: The index.
+    /// - Returns: The item at the specified index or `nil` if the index is not within range.
+    subscript(safeIndex index: Index) -> Element? {
+        guard indices.contains(index) else { return nil }
+        return self[index]
+    }
+}

--- a/Sources/Castor/Mutation.swift
+++ b/Sources/Castor/Mutation.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+enum Mutation<Element>: Equatable where Element: Hashable {
+    case move(element: Element, before: Element?)
+    case remove(element: Element)
+
+    static func mutations(from initial: [Element], to final: [Element]) -> [Self] {
+        var mutations: [Mutation<Element>] = []
+        var intermediate = initial
+        final.difference(from: initial).inferringMoves().forEach { change in
+            switch change {
+            case let .insert(offset: offset, element: element, associatedWith: associatedWith):
+                if associatedWith != nil {
+                    mutations.append(.move(element: element, before: intermediate[safeIndex: offset]))
+                }
+                intermediate.insert(element, at: offset)
+            case let .remove(offset: offset, element: element, associatedWith: associatedWith):
+                if associatedWith == nil {
+                    mutations.append(.remove(element: element))
+                }
+                intermediate.remove(at: offset)
+            }
+        }
+        return mutations
+    }
+}

--- a/Tests/CastorTests/CollectionTests.swift
+++ b/Tests/CastorTests/CollectionTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @testable import Castor
 
-@Suite("Collection")
+@Suite
 struct CollectionTests {
     @Test
     func safe_index() {

--- a/Tests/CastorTests/CollectionTests.swift
+++ b/Tests/CastorTests/CollectionTests.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Testing
+
+@testable import Castor
+
+@Suite("Collection")
+struct CollectionTests {
+    @Test
+    func safe_index() {
+        #expect([1, 2, 3][safeIndex: 0] == 1)
+        #expect([1, 2, 3][safeIndex: -1] == nil)
+        #expect([1, 2, 3][safeIndex: 3] == nil)
+    }
+}

--- a/Tests/CastorTests/ComparableTests.swift
+++ b/Tests/CastorTests/ComparableTests.swift
@@ -8,11 +8,14 @@
 
 import Testing
 
-@Test
-func clamped() {
-    #expect((-1).clamped(to: 0...1) == 0)
-    #expect(0.clamped(to: 0...1) == 0)
-    #expect(0.5.clamped(to: 0...1) == 0.5)
-    #expect(1.clamped(to: 0...1) == 1)
-    #expect(2.clamped(to: 0...1) == 1)
+@Suite
+struct ComparableTests {
+    @Test
+    func clamped() {
+        #expect((-1).clamped(to: 0...1) == 0)
+        #expect(0.clamped(to: 0...1) == 0)
+        #expect(0.5.clamped(to: 0...1) == 0.5)
+        #expect(1.clamped(to: 0...1) == 1)
+        #expect(2.clamped(to: 0...1) == 1)
+    }
 }

--- a/Tests/CastorTests/MutationTests.swift
+++ b/Tests/CastorTests/MutationTests.swift
@@ -1,0 +1,125 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Testing
+
+@testable import Castor
+
+@Suite
+struct MutationTests {
+    @Test
+    func empty() {
+        let initial: [String] = []
+        let final: [String] = []
+
+        #expect(Mutation.mutations(from: initial, to: final).isEmpty == true)
+    }
+
+    @Test
+    func remove_one_1() {
+        let initial = ["A"]
+        let final: [String] = []
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .remove(element: "A")
+        ])
+    }
+
+    @Test
+    func remove_one_2() {
+        let initial = ["A", "B", "C", "D"]
+        let final = ["A", "B", "C"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .remove(element: "D")
+        ])
+    }
+
+    @Test
+    func remove_many() {
+        let initial = ["A", "B", "C", "D"]
+        let final = ["A", "C"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .remove(element: "D"),
+            .remove(element: "B")
+        ])
+    }
+
+    @Test
+    func shift() {
+        let initial = ["A", "B", "C", "D", "E"]
+        let final = ["B", "C", "D", "E", "A"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .move(element: "A", before: nil)
+        ])
+    }
+
+    @Test
+    func identical() {
+        let initial = ["A", "B", "C", "D"]
+        let final = ["A", "B", "C", "D"]
+
+        #expect(Mutation.mutations(from: initial, to: final).isEmpty == true)
+    }
+
+    @Test
+    func not_identical_1() {
+        let initial = ["A", "B", "C", "D"]
+        let final = ["D", "B", "A", "C"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .move(element: "D", before: "B"),
+            .move(element: "A", before: "C")
+        ])
+    }
+    @Test
+    func not_identical_2() {
+        let initial = ["A", "B", "C", "D", "E"]
+        let final = ["D", "B", "E", "A", "C"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .move(element: "B", before: "E"),
+            .move(element: "A", before: nil),
+            .move(element: "C", before: nil)
+        ])
+    }
+
+    @Test
+    func not_identical_3() {
+        let initial = ["A", "B", "C", "D", "E"]
+        let final = ["E", "C", "A", "B", "D"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .move(element: "E", before: "A"),
+            .move(element: "C", before: "A")
+        ])
+    }
+
+    @Test
+    func not_identical_4() {
+        let initial = ["A", "B", "C", "D", "E"]
+        let final = ["B", "D", "A", "C", "E"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .move(element: "A", before: "E"),
+            .move(element: "C", before: "E")
+        ])
+    }
+
+    @Test
+    func not_identical_and_remove() {
+        let initial = ["A", "B", "C", "D", "E"]
+        let final = ["D", "E", "A", "C"]
+
+        #expect(Mutation.mutations(from: initial, to: final) == [
+            .remove(element: "B"),
+            .move(element: "A", before: nil),
+            .move(element: "C", before: nil)
+        ])
+    }
+}

--- a/Tests/CastorTests/RangeReplaceableTests.swift
+++ b/Tests/CastorTests/RangeReplaceableTests.swift
@@ -7,40 +7,43 @@
 @testable import Castor
 import Testing
 
-@Test
-func move_forward() {
-    var array = [1, 2, 3, 4, 5, 6, 7]
-    array.move(from: 2, to: 5)
-    #expect(array == [1, 2, 4, 5, 3, 6, 7])
-}
+@Suite
+struct RangeReplaceableTests {
+    @Test
+    func move_forward() {
+        var array = [1, 2, 3, 4, 5, 6, 7]
+        array.move(from: 2, to: 5)
+        #expect(array == [1, 2, 4, 5, 3, 6, 7])
+    }
 
-@Test
-func move_backward() {
-    var array = [1, 2, 3, 4, 5, 6, 7]
-    array.move(from: 5, to: 2)
-    #expect(array == [1, 2, 6, 3, 4, 5, 7])
-}
+    @Test
+    func move_backward() {
+        var array = [1, 2, 3, 4, 5, 6, 7]
+        array.move(from: 5, to: 2)
+        #expect(array == [1, 2, 6, 3, 4, 5, 7])
+    }
 
-@Test
-func move_to_end() {
-    var array = [1, 2, 3, 4, 5, 6, 7]
-    array.move(from: 2, to: 7)
-    #expect(array == [1, 2, 4, 5, 6, 7, 3])
-}
+    @Test
+    func move_to_end() {
+        var array = [1, 2, 3, 4, 5, 6, 7]
+        array.move(from: 2, to: 7)
+        #expect(array == [1, 2, 4, 5, 6, 7, 3])
+    }
 
-@Test
-func move_same_item() {
-    var array = [1, 2, 3, 4, 5, 6, 7]
-    array.move(from: 2, to: 2)
-    #expect(array == [1, 2, 3, 4, 5, 6, 7])
-}
+    @Test
+    func move_same_item() {
+        var array = [1, 2, 3, 4, 5, 6, 7]
+        array.move(from: 2, to: 2)
+        #expect(array == [1, 2, 3, 4, 5, 6, 7])
+    }
 
-@Test
-func move_from_invalid_index() {
-    // TODO: Implement once death tests are available: https://forums.swift.org/t/exit-tests-death-tests-and-you/71186
-}
+    @Test
+    func move_from_invalid_index() {
+        // TODO: Implement once death tests are available: https://forums.swift.org/t/exit-tests-death-tests-and-you/71186
+    }
 
-@Test
-func move_to_invalid_index() {
-    // TODO: Implement once death tests are available: https://forums.swift.org/t/exit-tests-death-tests-and-you/71186
+    @Test
+    func move_to_invalid_index() {
+        // TODO: Implement once death tests are available: https://forums.swift.org/t/exit-tests-death-tests-and-you/71186
+    }
 }


### PR DESCRIPTION
## Description

This PR solves remaining sync issues between sender and receiver (see associated issue).

## Changes made

- Fix local change replication (the changes that were triggered locally were simply not correctly reflected on the receiver).
- Avoid local playlist being synchronized too many times unnecessarily.
- Fix loops between senders when triggering a jump, which were unexpectedly ending sessions. 
- Ensure changes associated with current device / item selection are published. This ensures UI updates are performed ASAP when the selection changes. For example playlist arrow buttons in the demo can now be enabled/disabled as the playlist is navigated. Due to how `List` behaves, though, such changes cannot be published synchronously (i.e. immediately) via `@Published` properties. Changes are therefore published manually on the next run loop instead.
- Organize tests in suites.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
