### PR TITLE
Fetch item and associated metadata asynchronously

### DIFF
--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -250,7 +250,7 @@ private struct CastQueueCell: View {
 
     var body: some View {
         Text(metadata?.title ?? String(repeating: " ", count: .random(in: 20...40)))
-            .redacted(reason: metadata == nil ? .placeholder : [])
+            .redactedIfNil(metadata)
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -185,10 +185,7 @@ private struct CastQueueView: View {
         ZStack {
             if !queue.items.isEmpty {
                 List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { $item in
-                    CastQueueCell(metadata: item.metadata(from: queue))
-                        .onAppear {
-                            item.fetch(from: queue)
-                        }
+                    CastQueueCell(item: item)
                 }
             }
             else {
@@ -246,15 +243,16 @@ private struct CastQueueView: View {
 }
 
 private struct CastQueueCell: View {
-    let metadata: CastMetadata?
+    @ObservedObject var item: CastPlayerItem
 
     var body: some View {
         Text(title)
-            .redactedIfNil(metadata)
+            .onAppear(perform: item.fetch)
+            .redactedIfNil(item.metadata)
     }
 
     private var title: String {
-        guard let metadata else { return .placeholder(length: .random(in: 20...40)) }
+        guard let metadata = item.metadata else { return .placeholder(length: .random(in: 20...30)) }
         return metadata.title ?? "-"
     }
 }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -187,7 +187,7 @@ private struct CastQueueView: View {
                 List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { $item in
                     CastQueueCell(metadata: item.metadata(from: queue))
                         .onAppear {
-                            item.fetchMetadata(from: queue)
+                            item.fetch(from: queue)
                         }
                 }
             }

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -249,8 +249,13 @@ private struct CastQueueCell: View {
     let metadata: CastMetadata?
 
     var body: some View {
-        Text(metadata?.title ?? String(repeating: " ", count: .random(in: 20...40)))
+        Text(title)
             .redactedIfNil(metadata)
+    }
+
+    private var title: String {
+        guard let metadata else { return .placeholder(length: .random(in: 20...40)) }
+        return metadata.title ?? "-"
     }
 }
 

--- a/Demo/Sources/CastPlayerView.swift
+++ b/Demo/Sources/CastPlayerView.swift
@@ -184,8 +184,11 @@ private struct CastQueueView: View {
     private func list() -> some View {
         ZStack {
             if !queue.items.isEmpty {
-                List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { item in
-                    CastQueueCell(item: item.wrappedValue)
+                List($queue.items, id: \.self, editActions: .all, selection: queue.currentItemSelection) { $item in
+                    CastQueueCell(metadata: item.metadata(from: queue))
+                        .onAppear {
+                            item.fetchMetadata(from: queue)
+                        }
                 }
             }
             else {
@@ -243,11 +246,11 @@ private struct CastQueueView: View {
 }
 
 private struct CastQueueCell: View {
-    let item: CastPlayerItem
+    let metadata: CastMetadata?
 
     var body: some View {
-        Text(item.title ?? String(repeating: " ", count: .random(in: 20...40)))
-            .redacted(reason: item.title == nil ? .placeholder : [])
+        Text(metadata?.title ?? String(repeating: " ", count: .random(in: 20...40)))
+            .redacted(reason: metadata == nil ? .placeholder : [])
     }
 }
 

--- a/Demo/Sources/String.swift
+++ b/Demo/Sources/String.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+extension String {
+    static func placeholder(length: Int) -> String {
+        String(repeating: " ", count: length)
+    }
+}

--- a/Demo/Sources/View.swift
+++ b/Demo/Sources/View.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+extension View {
+    func redactedIfNil(_ object: Any?) -> some View {
+        redacted(reason: object == nil ? .placeholder : .init())
+    }
+}

--- a/Sources/Castor/CastCurrent.swift
+++ b/Sources/Castor/CastCurrent.swift
@@ -7,7 +7,7 @@
 import GoogleCast
 
 protocol CastCurrentDelegate: AnyObject {
-    func didUpdate(item: CastPlayerItem?)
+    func didUpdateItem(withId id: GCKMediaQueueItemID?)
 }
 
 /// This class is a workaround to avoid cast session instabilities when jumps are performed in quick succession.
@@ -50,16 +50,16 @@ extension CastCurrent: GCKRemoteMediaClientListener {
                 let isPendingItemReached = mediaStatus.currentItemID == pendingRequestItemId
                 let isPendingItemMissing = client.mediaQueue.indexOfItem(withID: pendingRequestItemId) == NSNotFound
                 if isPendingItemReached || isPendingItemMissing {
-                    delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
+                    delegate?.didUpdateItem(withId: mediaStatus.currentItemID)
                     self.pendingRequestItemId = nil
                 }
             }
             else {
-                delegate?.didUpdate(item: .init(id: mediaStatus.currentItemID))
+                delegate?.didUpdateItem(withId: mediaStatus.currentItemID)
             }
         }
         else {
-            delegate?.didUpdate(item: nil)
+            delegate?.didUpdateItem(withId: nil)
         }
     }
 }

--- a/Sources/Castor/CastError.swift
+++ b/Sources/Castor/CastError.swift
@@ -1,0 +1,9 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+enum CastError: Error {
+    case notFound
+}

--- a/Sources/Castor/CastMetadata.swift
+++ b/Sources/Castor/CastMetadata.swift
@@ -14,8 +14,4 @@ public struct CastMetadata {
     public var title: String? {
         rawMetadata?.string(forKey: kGCKMetadataKeyTitle)
     }
-
-    init(rawMetadata: GCKMediaMetadata?) {
-        self.rawMetadata = rawMetadata
-    }
 }

--- a/Sources/Castor/CastMetadata.swift
+++ b/Sources/Castor/CastMetadata.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+/// Metadata associated to an item.
+public struct CastMetadata {
+    let rawMetadata: GCKMediaMetadata?
+
+    /// The content title.
+    public var title: String? {
+        rawMetadata?.string(forKey: kGCKMetadataKeyTitle)
+    }
+
+    init(rawMetadata: GCKMediaMetadata?) {
+        self.rawMetadata = rawMetadata
+    }
+}

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -20,13 +20,13 @@ public struct CastPlayerItem: Hashable {
         self.id = id
     }
 
-    /// Asynchronously fetches item metadata from the specified queue.
+    /// Asynchronously fetches an item from the specified queue.
     ///
     /// - Parameter queue: The queue to retrieve metadata from.
     ///
     /// Fetching an item from a queue to which it does not belong leads to unexpected behavior.
-    public func fetchMetadata(from queue: CastQueue) {
-        queue.fetchMetadata(for: self)
+    public func fetch(from queue: CastQueue) {
+        queue.fetch(self)
     }
 
     /// Reads item metadata from the specified queue.
@@ -36,6 +36,7 @@ public struct CastPlayerItem: Hashable {
     /// Reading metadata for an item from a queue to which it does not belong leads to unexpected behavior. Metadata
     /// must be fetched first by calling ``fetchMetadata(from:)``.
     public func metadata(from queue: CastQueue) -> CastMetadata? {
-        queue.metadata(for: self)
+        guard let rawItem = queue.rawItem(for: self) else { return nil }
+        return .init(rawMetadata: rawItem.mediaInformation.metadata)
     }
 }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -33,7 +33,8 @@ public struct CastPlayerItem: Hashable {
     ///
     /// - Parameter queue: The queue to retrieve metadata from.
     ///
-    /// Reading metadata for an item from a queue to which it does not belong leads to unexpected behavior.
+    /// Reading metadata for an item from a queue to which it does not belong leads to unexpected behavior. Metadata
+    /// must be fetched first by calling ``fetchMetadata(from:)``.
     public func metadata(from queue: CastQueue) -> CastMetadata? {
         queue.metadata(for: self)
     }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -11,11 +11,6 @@ public struct CastPlayerItem: Hashable {
     /// The id.
     public let id: GCKMediaQueueItemID
 
-    /// The content title.
-    public var title: String? {
-        "\(id)"
-    }
-
     init(id: GCKMediaQueueItemID) {
         self.id = id
     }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -7,31 +7,43 @@
 import GoogleCast
 
 /// A cast player item.
-public struct CastPlayerItem: Hashable {
+public class CastPlayerItem: ObservableObject {
     /// The id.
     public let id: GCKMediaQueueItemID
 
-    init(id: GCKMediaQueueItemID) {
-        self.id = id
+    private let queue: CastQueue
+
+    /// The metadata associated with the item.
+    ///
+    /// Metadata must be retrieved by calling `fetch()`, for example on appearance of a view displaying the item.
+    public var metadata: CastMetadata? {
+        guard let rawItem = queue.rawItem(for: self) else { return nil }
+        return .init(rawMetadata: rawItem.mediaInformation.metadata)
     }
 
-    /// Asynchronously fetches an item from the specified queue.
-    ///
-    /// - Parameter queue: The queue to retrieve metadata from.
-    ///
-    /// Fetching an item from a queue to which it does not belong leads to unexpected behavior.
-    public func fetch(from queue: CastQueue) {
+    init(id: GCKMediaQueueItemID, queue: CastQueue) {
+        self.id = id
+        self.queue = queue
+    }
+
+    /// Fetch complete item information from the receiver.
+    public func fetch() {
         queue.fetch(self)
     }
 
-    /// Reads item metadata from the specified queue.
-    ///
-    /// - Parameter queue: The queue to retrieve metadata from.
-    ///
-    /// Reading metadata for an item from a queue to which it does not belong leads to unexpected behavior. Metadata
-    /// must be fetched first by calling ``fetchMetadata(from:)``.
-    public func metadata(from queue: CastQueue) -> CastMetadata? {
-        guard let rawItem = queue.rawItem(for: self) else { return nil }
-        return .init(rawMetadata: rawItem.mediaInformation.metadata)
+    func notifyUpdate() {
+        objectWillChange.send()
+    }
+}
+
+extension CastPlayerItem: Hashable {
+    // swiftlint:disable:next missing_docs
+    public static func == (lhs: CastPlayerItem, rhs: CastPlayerItem) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    // swiftlint:disable:next missing_docs
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -19,4 +19,22 @@ public struct CastPlayerItem: Hashable {
     init(id: GCKMediaQueueItemID) {
         self.id = id
     }
+
+    /// Asynchronously fetches item metadata from the specified queue.
+    ///
+    /// - Parameter queue: The queue to retrieve metadata from.
+    ///
+    /// Fetching an item from a queue to which it does not belong leads to unexpected behavior.
+    public func fetchMetadata(from queue: CastQueue) {
+        queue.fetchMetadata(for: self)
+    }
+
+    /// Reads item metadata from the specified queue.
+    ///
+    /// - Parameter queue: The queue to retrieve metadata from.
+    ///
+    /// Reading metadata for an item from a queue to which it does not belong leads to unexpected behavior.
+    public func metadata(from queue: CastQueue) -> CastMetadata? {
+        queue.metadata(for: self)
+    }
 }

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// A queue managing player items.
 public final class CastQueue: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
-    private var metadataCache: [GCKMediaQueueItemID: CastMetadata] = [:]
+    private var rawItemCache: [GCKMediaQueueItemID: GCKMediaQueueItem] = [:]
 
     /// The items in the queue.
     ///
@@ -182,19 +182,18 @@ public extension CastQueue {
 }
 
 extension CastQueue {
-    func fetchMetadata(for item: CastPlayerItem) {
-        guard metadata(for: item) == nil else { return }
+    func fetch(_ item: CastPlayerItem) {
+        guard rawItem(for: item) == nil else { return }
         remoteMediaClient.mediaQueue.item(withID: item.id)
     }
 
-    func metadata(for item: CastPlayerItem) -> CastMetadata? {
-        if let metadata = metadataCache[item.id] {
-            return metadata
+    func rawItem(for item: CastPlayerItem) -> GCKMediaQueueItem? {
+        if let rawItem = rawItemCache[item.id] {
+            return rawItem
         }
         else if let rawItem = remoteMediaClient.mediaQueue.item(withID: item.id, fetchIfNeeded: false) {
-            let metadata = CastMetadata(rawMetadata: rawItem.mediaInformation.metadata)
-            metadataCache[item.id] = metadata
-            return metadata
+            rawItemCache[item.id] = rawItem
+            return rawItem
         }
         else {
             return nil

--- a/Sources/Castor/Extensions/GCKMediaQueue.swift
+++ b/Sources/Castor/Extensions/GCKMediaQueue.swift
@@ -7,6 +7,7 @@
 import GoogleCast
 
 extension GCKMediaQueue {
+    @discardableResult
     func item(withID itemID: GCKMediaQueueItemID, fetchIfNeeded: Bool = true) -> GCKMediaQueueItem? {
         let index = indexOfItem(withID: itemID)
         return index != NSNotFound ? item(at: UInt(index), fetchIfNeeded: fetchIfNeeded) : nil

--- a/Sources/Castor/Extensions/GCKMediaQueue.swift
+++ b/Sources/Castor/Extensions/GCKMediaQueue.swift
@@ -7,6 +7,10 @@
 import GoogleCast
 
 extension GCKMediaQueue {
+    func itemIDs() -> [GCKMediaQueueItemID] {
+        (0..<itemCount).map { itemID(at: $0) }
+    }
+
     @discardableResult
     func item(withID itemID: GCKMediaQueueItemID, fetchIfNeeded: Bool = true) -> GCKMediaQueueItem? {
         let index = indexOfItem(withID: itemID)


### PR DESCRIPTION
## Description

This PR introduces an API to fetch item and associated metadata asynchronously.

## Implementation considerations

The Google Cast SDK fetches and keeps metadata for 20 items at most in an [LRU cache](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_media_queue). We therefore need fetch/metadata APIs that leverage this LRU cache to efficiently retrieve recent items first (i.e. those most recently seen by the user), but also ensure that metadata for > 20 items is available. This requires another cache managed by our implementation directly.

Item fetch and metadata APIs ultimately need collaboration from a parent queue, but we hide this relationship from `CastPlayerItem` public interface to make our API as ergonomic as possible. Items can therefore be fetched without any explicit reference to their queue in parent code. For SwiftUI to correctly trigger refreshes once an item has been fetched, though, we need to make `CastPlayerItem` observable, with the queue manually triggering the actual change notification when metadata has been fetched.

Since items are now observable objects, and therefore reference types, we cannot just throw them away and recreate them as we were with structs. Instead we must preserve existing items so that SwiftUI observation continuity is guaranteed. For this reason the queue sync logic has been updated to perform diffing, reusing existing items instead of creating new ones. For the same reason the `CastCurrent` returns ids to its delegate on current item change, which can be used to find an existing matching item (instead of creating a new one).

Since the current item is received from `mediaStatus`, though, which is faster updated than the queue, we need to store the id and to ensure the current item is updated when information is complete (local item list and id available). We therefore added an item lookup method that throws when information is incomplete, or returns an item/`nil` when the current item could be determined. This lookup method is then used for updating the current item once either the item list changes, or the current item id changes.

## Changes made

- Make `CastPlayerItem` an `ObservableObject`, and thus a class.
- Make `CastPlayerItem` hashable, relying on its fundamental constant property (`id`) for implementation.
- Add `CastQueue` methods for fetching and reading metadata, with a local cache circumventing the 20-item limit of `GCKMediaQueue`.
- Reuse existing items as much as possible when performing local updates. This is achieved by diffing id lists and mirroring the changes on a local copy of the items, so that no item is unnecessarily destroyed.
- Update the demo to fetch items and display their metadata.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
