### PR TITLE
Remove non-needed workarounds

### DIFF
--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -29,16 +29,13 @@ public final class Cast: NSObject, ObservableObject {
     /// Ends the session if set to `nil`.
     ///
     /// > Important: On iOS 18.3 and below use `currentDeviceSelection` to manage selection in a `List`.
-    public var currentDevice: CastDevice? {
+    @Published public var currentDevice: CastDevice? {
         didSet {
             if let currentDevice {
                 moveSession(from: oldValue, to: currentDevice)
             }
             else {
                 endSession()
-            }
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
             }
         }
     }

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -40,7 +40,7 @@ public final class CastQueue: NSObject, ObservableObject {
     /// Stops playback if set to `nil`.
     ///
     /// > Important: On iOS 18.3 and below use `currentItemSelection` to manage selection in a `List`.
-    public var currentItem: CastPlayerItem? {
+    @Published public var currentItem: CastPlayerItem? {
         didSet {
             if let currentItem {
                 guard currentItem != oldValue else { return }
@@ -48,9 +48,6 @@ public final class CastQueue: NSObject, ObservableObject {
             }
             else {
                 remoteMediaClient.stop()
-            }
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
             }
         }
     }


### PR DESCRIPTION
## Description

This PR removes a non-needed workaround for _Publishing changes from within view updates_ triggered in `Lists` where the selection is bound to a published property. This was likely an issue with beta Xcode releases but the issue has vanished with Xcode 16.3.

## Changes made

- Replace manual delayed updates with standard `@Published` properties.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
