### PR TITLE
Add presenter mode

### DIFF
--- a/Demo/Castor-demo.xcodeproj/project.pbxproj
+++ b/Demo/Castor-demo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0EFEFEF72D4916A1003034F7 /* Castor in Frameworks */ = {isa = PBXBuildFile; productRef = 0EFEFEF62D4916A1003034F7 /* Castor */; };
+		6F93E3812D9C0CEA00B412AA /* ShowTime in Frameworks */ = {isa = PBXBuildFile; productRef = 6F93E3802D9C0CEA00B412AA /* ShowTime */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -67,6 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F93E3812D9C0CEA00B412AA /* ShowTime in Frameworks */,
 				0EFEFEF72D4916A1003034F7 /* Castor in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -124,6 +126,7 @@
 			name = "Castor-demo";
 			packageProductDependencies = (
 				0EFEFEF62D4916A1003034F7 /* Castor */,
+				6F93E3802D9C0CEA00B412AA /* ShowTime */,
 			);
 			productName = "Castor-demo";
 			productReference = 0ECF4A4D2D48E1F400238371 /* Castor-demo.app */;
@@ -153,6 +156,9 @@
 			);
 			mainGroup = 0ECF4A442D48E1F400238371;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				6F93E37F2D9C0CEA00B412AA /* XCRemoteSwiftPackageReference "ShowTime" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0ECF4A4E2D48E1F400238371 /* Products */;
 			projectDirPath = "";
@@ -496,10 +502,26 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		6F93E37F2D9C0CEA00B412AA /* XCRemoteSwiftPackageReference "ShowTime" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/KaneCheshire/ShowTime.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.3;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		0EFEFEF62D4916A1003034F7 /* Castor */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Castor;
+		};
+		6F93E3802D9C0CEA00B412AA /* ShowTime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6F93E37F2D9C0CEA00B412AA /* XCRemoteSwiftPackageReference "ShowTime" */;
+			productName = ShowTime;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/Sources/DemoApp.swift
+++ b/Demo/Sources/DemoApp.swift
@@ -6,15 +6,28 @@
 
 import AVFAudio
 import Castor
+import Combine
 import GoogleCast
+import ShowTime
 import SwiftUI
 
 private final class AppDelegate: NSObject, UIApplicationDelegate {
+    private var cancellables = Set<AnyCancellable>()
+
     // swiftlint:disable:next discouraged_optional_collection
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         try? AVAudioSession.sharedInstance().setCategory(.playback)
+        configureShowTime()
         configureGoogleCast()
         return true
+    }
+
+    private func configureShowTime() {
+        UserDefaults.standard.publisher(for: \.presenterModeEnabled)
+            .sink { isEnabled in
+                ShowTime.enabled = isEnabled ? .always : .never
+            }
+            .store(in: &cancellables)
     }
 
     private func configureGoogleCast() {

--- a/Demo/Sources/Extensions/UserDefaults.swift
+++ b/Demo/Sources/Extensions/UserDefaults.swift
@@ -8,7 +8,12 @@ import Foundation
 
 extension UserDefaults {
     enum DemoSettingKey {
-        static let receiver = "CastorDemoReceiver"
+        static let receiver = "receiver"
+        static let presenterModeEnabled = "presenterModeEnabled"
+    }
+
+    @objc dynamic var presenterModeEnabled: Bool {
+        bool(forKey: DemoSettingKey.presenterModeEnabled)
     }
 
     @objc dynamic var receiver: Receiver {

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -9,6 +9,9 @@ import GoogleCast
 import SwiftUI
 
 struct SettingsView: View {
+    @AppStorage(UserDefaults.DemoSettingKey.presenterModeEnabled)
+    private var isPresenterModeEnabled = false
+
     @AppStorage(UserDefaults.DemoSettingKey.receiver)
     private var receiver: Receiver = .standard
 
@@ -27,11 +30,23 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+            applicationSection()
             receiverSection()
             versionSection()
         }
         .onChange(of: receiver) { _, _ in exit(0) }
         .navigationTitle("Settings")
+    }
+
+    private func applicationSection() -> some View {
+        Section {
+            Toggle(isOn: $isPresenterModeEnabled) {
+                Text("Presenter mode")
+                Text("Displays touches for presentation purposes.").font(.footnote)
+            }
+        } header: {
+            Text("Application")
+        }
     }
 
     private func receiverSection() -> some View {

--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "3aeee2495b3bb03737d5105dbf21afdd6b267658",
         "version" : "4.8.3"
       }
+    },
+    {
+      "identity" : "showtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/KaneCheshire/ShowTime.git",
+      "state" : {
+        "revision" : "f4e976931fc5f9b7a7d011f40c62a250c4ff53ab",
+        "version" : "2.5.3"
+      }
     }
   ],
   "version" : 2


### PR DESCRIPTION
## Description

This PR adds presenter mode to the demo using ShowTime.

## Changes made

- Add ShowTime.
- Add presenter mode setting.
- Fix setting change observation (key path and underlying setting name must match for KVO to work).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with both the standard (`CC1AD845`) and DRM-enabled (`A12D4273`) Google Cast receivers.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
