### PR TITLE
Make the SRGSSR receiver support URLs

### DIFF
--- a/Sources/Castor/CastAsset.swift
+++ b/Sources/Castor/CastAsset.swift
@@ -16,7 +16,11 @@ public struct CastAsset {
         func mediaInformationBuilder() -> GCKMediaInformationBuilder {
             switch self {
             case let .simple(url):
-                return GCKMediaInformationBuilder(contentURL: url)
+                let builder = GCKMediaInformationBuilder(contentURL: url)
+                // TODO: This workaround should be removed.
+                // A random contentID is currently set to enable playback of URL based content using the SRGSSR receiver.
+                builder.contentID = UUID().uuidString
+                return builder
             case let .custom(id):
                 let builder = GCKMediaInformationBuilder()
                 builder.contentID = id


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- Set `contentID` with a random `UUID`. 

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
