### PR TITLE
Fix device cell alignment

### DIFF
--- a/Demo/Sources/DevicesView.swift
+++ b/Demo/Sources/DevicesView.swift
@@ -52,13 +52,20 @@ struct DevicesView: View {
 
     private func devicesView() -> some View {
         List(cast.devices, id: \.self, selection: $cast.currentDevice) { device in
-            HStack {
+            Label {
+                label(for: device)
+            } icon: {
                 Image(systemName: Self.imageName(for: device))
-                descriptionView(for: device)
-                if cast.isCasting(on: device) {
-                    Spacer()
-                    statusView()
-                }
+            }
+        }
+    }
+
+    private func label(for device: CastDevice) -> some View {
+        HStack {
+            descriptionView(for: device)
+            if cast.isCasting(on: device) {
+                Spacer()
+                statusView()
             }
         }
     }

--- a/Demo/Sources/Player/PlaylistView.swift
+++ b/Demo/Sources/Player/PlaylistView.swift
@@ -12,26 +12,29 @@ private struct ItemCell: View {
 
     var body: some View {
         HStack(spacing: 30) {
-            AsyncImage(url: item.metadata?.imageUrl) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            } placeholder: {
-                Image(systemName: "photo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            }
-            .frame(width: 80, height: 45)
-
+            image()
             Text(title)
-                .onAppear(perform: item.fetch)
-                .redactedIfNil(item.metadata)
         }
+        .onAppear(perform: item.fetch)
+        .redactedIfNil(item.metadata)
     }
 
     private var title: String {
         guard let metadata = item.metadata else { return .placeholder(length: .random(in: 20...30)) }
         return metadata.title ?? "-"
+    }
+
+    private func image() -> some View {
+        AsyncImage(url: item.metadata?.imageUrl) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } placeholder: {
+            Image(systemName: "photo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        }
+        .frame(width: 80, height: 45)
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes device cell alignment so that texts are properly leading-aligned.

| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/bc71f9e8-b7fd-4ff4-9823-212e608d52e7) | ![After](https://github.com/user-attachments/assets/3ce35bfb-4cbb-4a99-ae9e-c9fe8635f86f) | 

## Changes made

- Use `Label` to provide for automatic content alignment between `List` cells.
- Improve item cell layout, extending placeholder appearance to the image as well.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
