### PR TITLE
Fix memory management issues

### DIFF
--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -53,4 +53,5 @@ struct ExamplesView: View {
     NavigationStack {
         ExamplesView()
     }
+    .environmentObject(Cast())
 }

--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -17,7 +17,7 @@ struct CastPlayerView: View {
                 PlaylistView(queue: player.queue)
             }
             else {
-                MessageView(message: "Not connected", icon: .system("wifi.slash"))
+                MessageView(message: "Not connected", icon: .system("play.slash.fill"))
                     .overlay(alignment: .topTrailing) {
                         ProgressView()
                             .padding()

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -24,7 +24,9 @@ struct SettingsView: View {
     }
 
     private var applicationIdentifier: String? {
-        let applicationIdentifier = Bundle.main.infoDictionary!["TestFlightApplicationIdentifier"] as! String
+        guard let applicationIdentifier = Bundle.main.infoDictionary?["TestFlightApplicationIdentifier"] as? String else {
+            return nil
+        }
         return !applicationIdentifier.isEmpty ? applicationIdentifier : nil
     }
 
@@ -96,14 +98,15 @@ struct SettingsView: View {
 
 private extension SettingsView {
     static func testFlightUrl(forApplicationIdentifier applicationIdentifier: String) -> URL? {
-        var url = URL("itms-beta://beta.itunes.apple.com/v1/app/")
-            .appending(path: applicationIdentifier)
-        if !UIApplication.shared.canOpenURL(url) {
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-            components.scheme = "https"
-            url = components.url!
+        let url = URL(string: "itms-beta://beta.itunes.apple.com/v1/app/")!.appending(path: applicationIdentifier)
+        if UIApplication.shared.canOpenURL(url) {
+            return url
         }
-        return url
+        else {
+            guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+            components.scheme = "https"
+            return components.url
+        }
     }
 
     func openTestFlight(forApplicationIdentifier applicationIdentifier: String?) {
@@ -115,5 +118,7 @@ private extension SettingsView {
 }
 
 #Preview {
-    SettingsView()
+    NavigationStack {
+        SettingsView()
+    }
 }

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// This object that handles everything related to Google Cast.
 public final class Cast: NSObject, ObservableObject {
-    /// The player version.
+    /// The package version.
     public static let version = PackageInfo.version
 
     private let context = GCKCastContext.sharedInstance()

--- a/Sources/Castor/CastAsset.swift
+++ b/Sources/Castor/CastAsset.swift
@@ -4,10 +4,9 @@
 //  License information is available from the LICENSE file.
 //
 
-import Foundation
 import GoogleCast
 
-/// An cast asset representing content to be played.
+/// A cast asset representing content to be played.
 public struct CastAsset {
     private enum Kind {
         case simple(URL)

--- a/Sources/Castor/CastError.swift
+++ b/Sources/Castor/CastError.swift
@@ -1,9 +1,0 @@
-//
-//  Copyright (c) SRG SSR. All rights reserved.
-//
-//  License information is available from the LICENSE file.
-//
-
-enum CastError: Error {
-    case notFound
-}

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -16,7 +16,7 @@ public final class CastPlayer: NSObject, ObservableObject {
     @Published private var mediaStatus: GCKMediaStatus?
 
     /// The queue managing player items.
-    public var queue: CastQueue
+    public let queue: CastQueue
 
     init?(remoteMediaClient: GCKRemoteMediaClient?) {
         guard let remoteMediaClient else { return nil }

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -29,10 +29,6 @@ public final class CastPlayer: NSObject, ObservableObject {
 
         remoteMediaClient.add(self)
     }
-
-    deinit {
-        remoteMediaClient.mediaQueue.remove(queue)
-    }
 }
 
 public extension CastPlayer {

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -29,6 +29,10 @@ public final class CastPlayer: NSObject, ObservableObject {
 
         remoteMediaClient.add(self)
     }
+
+    deinit {
+        queue.release()
+    }
 }
 
 public extension CastPlayer {

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -11,7 +11,7 @@ public final class CastPlayerItem: ObservableObject {
     /// The id.
     public let id: GCKMediaQueueItemID
 
-    private let queue: CastQueue
+    private weak var queue: CastQueue?
 
     // swiftlint:disable:next legacy_objc_type
     var idNumber: NSNumber {
@@ -22,7 +22,7 @@ public final class CastPlayerItem: ObservableObject {
     ///
     /// Metadata must be retrieved by calling `fetch()`, for example on appearance of a view displaying the item.
     public var metadata: CastMetadata? {
-        guard let rawItem = queue.rawItem(for: self) else { return nil }
+        guard let rawItem = queue?.rawItem(for: self) else { return nil }
         return .init(rawMetadata: rawItem.mediaInformation.metadata)
     }
 
@@ -33,7 +33,7 @@ public final class CastPlayerItem: ObservableObject {
 
     /// Fetch complete item information from the receiver.
     public func fetch() {
-        queue.fetch(self)
+        queue?.fetch(self)
     }
 
     func notifyUpdate() {

--- a/Sources/Castor/CastPlayerItem.swift
+++ b/Sources/Castor/CastPlayerItem.swift
@@ -7,7 +7,7 @@
 import GoogleCast
 
 /// A cast player item.
-public class CastPlayerItem: ObservableObject {
+public final class CastPlayerItem: ObservableObject {
     /// The id.
     public let id: GCKMediaQueueItemID
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -24,7 +24,13 @@ public final class CastQueue: NSObject, ObservableObject {
     ///   be performed asynchronously on the receiver.
     @Published public var items: [CastPlayerItem] = [] {
         didSet {
-            try? currentItem = Self.findItem(withId: currentItemId, in: items)
+            print("--> items: \(items.count)")
+            if !items.isEmpty {
+                try? currentItem = Self.findItem(withId: currentItemId, in: items)
+            }
+            else {
+                currentItem = nil
+            }
             guard canRequest else { return }
             requestUpdates(from: oldValue, to: items)
         }
@@ -42,6 +48,8 @@ public final class CastQueue: NSObject, ObservableObject {
     /// > Important: On iOS 18.3 and below use `currentItemSelection` to manage selection in a `List`.
     @Published public var currentItem: CastPlayerItem? {
         didSet {
+            print("--> did set curr: \(currentItem)")
+            guard canRequest else { return }
             if let currentItem {
                 guard currentItem != oldValue else { return }
                 current.jump(to: currentItem.id)

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -24,7 +24,6 @@ public final class CastQueue: NSObject, ObservableObject {
     ///   be performed asynchronously on the receiver.
     @Published public var items: [CastPlayerItem] = [] {
         didSet {
-            print("--> items: \(items.count)")
             if !items.isEmpty {
                 try? currentItem = Self.findItem(withId: currentItemId, in: items)
             }
@@ -48,7 +47,6 @@ public final class CastQueue: NSObject, ObservableObject {
     /// > Important: On iOS 18.3 and below use `currentItemSelection` to manage selection in a `List`.
     @Published public var currentItem: CastPlayerItem? {
         didSet {
-            print("--> did set curr: \(currentItem)")
             guard canRequest else { return }
             if let currentItem {
                 guard currentItem != oldValue else { return }

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -358,12 +358,7 @@ private extension CastQueue {
 private extension CastQueue {
     func updateCurrentItem() {
         canJump = false
-        if let currentItemId {
-            currentItem = items.first { $0.id == currentItemId }
-        }
-        else {
-            currentItem = nil
-        }
+        currentItem = items.first { $0.id == currentItemId }
         canJump = true
     }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -15,7 +15,7 @@ public final class CastQueue: NSObject, ObservableObject {
     private var currentItemId: GCKMediaQueueItemID? {
         didSet {
             canRequest = false
-            Self.extractItem(withId: currentItemId, from: items, into: &currentItem)
+            updateCurrentItem()
             canRequest = true
         }
     }
@@ -26,7 +26,7 @@ public final class CastQueue: NSObject, ObservableObject {
     ///   be performed asynchronously on the receiver.
     @Published public var items: [CastPlayerItem] = [] {
         didSet {
-            Self.extractItem(withId: currentItemId, from: items, into: &currentItem)
+            updateCurrentItem()
             guard canRequest else { return }
             requestUpdates(from: oldValue, to: items)
         }
@@ -356,14 +356,14 @@ private extension CastQueue {
 }
 
 private extension CastQueue {
-    static func extractItem(withId id: GCKMediaQueueItemID?, from items: [CastPlayerItem], into item: inout CastPlayerItem?) {
-        if !items.isEmpty, let id {
+    func updateCurrentItem() {
+        if !items.isEmpty, let currentItemId {
             // The current item id is updated separately from the list of items. Inhibit updates when not in sync.
-            guard let matchingItem = items.first(where: { $0.id == id }) else { return }
-            item = matchingItem
+            guard let matchingItem = items.first(where: { $0.id == currentItemId }) else { return }
+            currentItem = matchingItem
         }
         else {
-            item = nil
+            currentItem = nil
         }
     }
 

--- a/Sources/Castor/CastQueue.swift
+++ b/Sources/Castor/CastQueue.swift
@@ -93,7 +93,11 @@ public final class CastQueue: NSObject, ObservableObject {
         self.current = .init(remoteMediaClient: remoteMediaClient)
         super.init()
         self.current.delegate = self
-        remoteMediaClient.mediaQueue.add(self)
+        remoteMediaClient.mediaQueue.add(self)          // The delegate is retained
+    }
+
+    func release() {
+        remoteMediaClient.mediaQueue.remove(self)
     }
 }
 


### PR DESCRIPTION
## Description

This PR makes varuous improvements to our implementation, found during implementation of [Mini Castor](https://github.com/SRGSSR/mini-castor). Most notably some memory management issues were found, in particular related to weird Google Cast API design choices (retained delegates).

## Changes made

- Avoid retain cycle between `CastQueue` and `CastPlayerItem`.
- Revisit current item management so that `currentItem` is updated consistently, e.g. to `nil` when clearing the `items` list.
- Avoid `CastQueue` retaining itself, leading to a leak.
- Make icon displayed when no session has been established more informative.
- Fix crashing example and settings previews.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
