### PR TITLE
Avoid resizable playback button

### DIFF
--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -110,7 +110,9 @@ struct ControlsView: View {
             Image(systemName: imageName)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .frame(height: 60)
         }
+        .frame(width: 60)
     }
 
     private func stopButton() -> some View {
@@ -118,7 +120,9 @@ struct ControlsView: View {
             Image(systemName: "stop.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .frame(height: 60)
         }
+        .frame(width: 60)
     }
 
     private func buttons() -> some View {
@@ -126,7 +130,6 @@ struct ControlsView: View {
             playbackButton()
             stopButton()
         }
-        .frame(height: 60)
     }
 
     private func informationView() -> some View {


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- The button width has been fixed.

https://github.com/user-attachments/assets/a5fcd9bb-0e19-48de-889d-2af009297ea4

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
