### PR TITLE
Add DASH streams

### DIFF
--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -14,8 +14,10 @@ struct ExamplesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            List(kMedias) { media in
-                button(for: media)
+            List {
+                section("HLS", medias: kHlsUrlMedias)
+                section("DASH", medias: kDashUrlMedias)
+                section("URN", medias: kHlsUrlMedias)
             }
             if cast.player != nil {
                 MiniMediaControlsView()
@@ -45,6 +47,14 @@ struct ExamplesView: View {
             }
         } label: {
             Text(media.title)
+        }
+    }
+
+    private func section(_ titleKey: LocalizedStringKey, medias: [Media]) -> some View {
+        Section(titleKey) {
+            ForEach(medias) { media in
+                button(for: media)
+            }
         }
     }
 }

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -16,8 +16,12 @@ struct ExamplesView: View {
         VStack(spacing: 0) {
             List {
                 section("HLS", medias: kHlsUrlMedias)
-                section("DASH", medias: kDashUrlMedias)
-                section("URN", medias: kHlsUrlMedias)
+                if cast.player != nil {
+                    section("DASH", medias: kDashUrlMedias)
+                    if UserDefaults.standard.receiver == .srgssr {
+                        section("URN", medias: kUrnMedias)
+                    }
+                }
             }
             if cast.player != nil {
                 MiniMediaControlsView()

--- a/Demo/Sources/Medias.swift
+++ b/Demo/Sources/Medias.swift
@@ -41,9 +41,14 @@ let kHlsUrlMedias: [Media] = [
 
 let kDashUrlMedias: [Media] = [
     .init(
-        title: "VOD (h264)",
+        title: "VOD",
+        imageUrl: "https://dashif.org/img/dashif-logo-283x100_new.jpg",
+        type: .url("https://dash.akamaized.net/dash264/TestCases/1a/netflix/exMPD_BIP_TC1.mpd")
+    ),
+    .init(
+        title: "Live",
         imageUrl: "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg",
-        type: .url("https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd")
+        type: .url("https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd?time_shift=300")
     )
 ]
 

--- a/Demo/Sources/Medias.swift
+++ b/Demo/Sources/Medias.swift
@@ -6,8 +6,6 @@
 
 import Foundation
 
-let kMedias = kHlsUrlMedias + kDashUrlMedias + kUrnMedias
-
 let kHlsUrlMedias: [Media] = [
     .init(
         title: "Apple Basic 4:3",

--- a/Demo/Sources/Medias.swift
+++ b/Demo/Sources/Medias.swift
@@ -47,7 +47,7 @@ let kDashUrlMedias: [Media] = [
     ),
     .init(
         title: "Live",
-        imageUrl: "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg",
+        imageUrl: "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png",
         type: .url("https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd?time_shift=300")
     )
 ]

--- a/Demo/Sources/Medias.swift
+++ b/Demo/Sources/Medias.swift
@@ -6,13 +6,9 @@
 
 import Foundation
 
-let kMedias = UserDefaults.standard.receiver == .srgssr ? (kUrlMedias + kUrnMedias) : kUrlMedias
+let kMedias = kHlsUrlMedias + kDashUrlMedias + kUrnMedias
 
-private let kAppleImageUrl = URL(
-    string: "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
-)!
-
-private let kUrlMedias: [Media] = [
+let kHlsUrlMedias: [Media] = [
     .init(
         title: "Apple Basic 4:3",
         imageUrl: kAppleImageUrl,
@@ -45,7 +41,15 @@ private let kUrlMedias: [Media] = [
     )
 ]
 
-private let kUrnMedias: [Media] = [
+let kDashUrlMedias: [Media] = [
+    .init(
+        title: "VOD (h264)",
+        imageUrl: "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg",
+        type: .url("https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd")
+    )
+]
+
+let kUrnMedias: [Media] = [
     .init(
         title: "Horizontal video",
         imageUrl: "https://www.rts.ch/2024/04/10/19/23/14827621.image/16x9",
@@ -67,3 +71,7 @@ private let kUrnMedias: [Media] = [
         type: .urn("urn:srf:video:40ca0277-0e53-4312-83e2-4710354ff53e")
     )
 ]
+
+private let kAppleImageUrl = URL(
+    string: "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
+)!

--- a/Demo/Sources/Player/PlaylistSelectionView.swift
+++ b/Demo/Sources/Player/PlaylistSelectionView.swift
@@ -49,9 +49,21 @@ struct PlaylistSelectionView: View {
     }
 
     private func list() -> some View {
-        let medias = kHlsUrlMedias + kDashUrlMedias + kUrnMedias
-        return List(medias, id: \.self, selection: $selectedMedias) { media in
-            Text(media.title)
+        List(selection: $selectedMedias) {
+            section("HLS", medias: kHlsUrlMedias)
+            section("DASH", medias: kDashUrlMedias)
+            if UserDefaults.standard.receiver == .srgssr {
+                section("URN", medias: kUrnMedias)
+            }
+        }
+    }
+
+    private func section(_ titleKey: LocalizedStringKey, medias: [Media]) -> some View {
+        Section(titleKey) {
+            ForEach(medias) { media in
+                Text(media.title)
+                    .tag(media)
+            }
         }
     }
 

--- a/Demo/Sources/Player/PlaylistSelectionView.swift
+++ b/Demo/Sources/Player/PlaylistSelectionView.swift
@@ -49,7 +49,8 @@ struct PlaylistSelectionView: View {
     }
 
     private func list() -> some View {
-        List(kMedias, id: \.self, selection: $selectedMedias) { media in
+        let medias = kHlsUrlMedias + kDashUrlMedias + kUrnMedias
+        return List(medias, id: \.self, selection: $selectedMedias) { media in
             Text(media.title)
         }
     }

--- a/Sources/Castor/CastAsset.swift
+++ b/Sources/Castor/CastAsset.swift
@@ -61,6 +61,7 @@ public struct CastAsset {
     private func mediaInformation() -> GCKMediaInformation {
         let builder = kind.mediaInformationBuilder()
         builder.metadata = metadata.rawMetadata
+        builder.streamType = .unknown
         return builder.build()
     }
 }


### PR DESCRIPTION
## Description

This PR allows us to add some **DASH** streams and also to set the media information stream type to `.unknown` to benefit of the auto selection of stream type by the SDK / receiver.

## Changes made

- The **Examples** tab has been split into different sections (**HLS**, **DASH** and **URN**)
- The playlist selection has also been split as the previous point
- The media information stream type has been set to `.unknown` by default

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
