### PR TITLE
Support Skips

### DIFF
--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -122,6 +122,7 @@ struct ControlsView: View {
                 .frame(height: 60)
         }
         .frame(width: 60)
+        .disabled(!player.canSkipBackward())
     }
 
     private func playbackButton() -> some View {
@@ -152,6 +153,7 @@ struct ControlsView: View {
                 .frame(height: 60)
         }
         .frame(width: 60)
+        .disabled(!player.canSkipBackward())
     }
 
     private func skipToDefaultButton() -> some View {
@@ -162,6 +164,7 @@ struct ControlsView: View {
                 .frame(height: 60)
         }
         .frame(width: 60)
+        .disabled(!player.canSkipToDefault())
     }
 
     private func buttons() -> some View {

--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -84,23 +84,24 @@ struct ControlsView: View {
             .animation(.default, value: player.isBusy)
     }
 
-    @ViewBuilder
     private func slider() -> some View {
-        if progressTracker.isProgressAvailable {
-            Slider(
-                progressTracker: progressTracker,
-                label: {
-                    Text("Current position")
-                },
-                minimumValueLabel: {
-                    label(withText: Self.formattedTime(progressTracker.time, duration: progressTracker.timeRange.duration))
-                },
-                maximumValueLabel: {
-                    label(withText: Self.formattedTime(progressTracker.timeRange.duration, duration: progressTracker.timeRange.duration))
-                }
-            )
-            .frame(height: 30)
+        ZStack {
+            if progressTracker.isProgressAvailable {
+                Slider(
+                    progressTracker: progressTracker,
+                    label: {
+                        Text("Current position")
+                    },
+                    minimumValueLabel: {
+                        label(withText: Self.formattedTime(progressTracker.time, duration: progressTracker.timeRange.duration))
+                    },
+                    maximumValueLabel: {
+                        label(withText: Self.formattedTime(progressTracker.timeRange.duration, duration: progressTracker.timeRange.duration))
+                    }
+                )
+            }
         }
+        .frame(height: 30)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -113,6 +113,16 @@ struct ControlsView: View {
         }
     }
 
+    private func skipBackwardButton() -> some View {
+        Button(action: player.skipBackward) {
+            Image(systemName: "gobackward.10")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 60)
+        }
+        .frame(width: 60)
+    }
+
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
             Image(systemName: imageName)
@@ -133,10 +143,22 @@ struct ControlsView: View {
         .frame(width: 60)
     }
 
+    private func skipForwardButton() -> some View {
+        Button(action: player.skipForward) {
+            Image(systemName: "goforward.10")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 60)
+        }
+        .frame(width: 60)
+    }
+
     private func buttons() -> some View {
         HStack(spacing: 40) {
+            skipBackwardButton()
             playbackButton()
             stopButton()
+            skipForwardButton()
         }
     }
 

--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -154,12 +154,23 @@ struct ControlsView: View {
         .frame(width: 60)
     }
 
+    private func skipToDefaultButton() -> some View {
+        Button(action: player.skipToDefault) {
+            Image(systemName: "forward.end.fill")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 60)
+        }
+        .frame(width: 60)
+    }
+
     private func buttons() -> some View {
         HStack(spacing: 40) {
             skipBackwardButton()
             playbackButton()
             stopButton()
             skipForwardButton()
+            skipToDefaultButton()
         }
     }
 

--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -110,7 +110,7 @@ struct ControlsView: View {
             Text(text)
                 .font(.caption)
                 .monospacedDigit()
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
         }
     }
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -18,11 +18,12 @@ public final class Cast: NSObject, ObservableObject {
 
     private var currentSession: GCKCastSession? {
         didSet {
-            player = .init(remoteMediaClient: currentSession?.remoteMediaClient)
+            player = .init(remoteMediaClient: currentSession?.remoteMediaClient, configuration: configuration)
         }
     }
 
     private var targetDevice: CastDevice?
+    private let configuration: CastConfiguration
 
     /// The current device.
     ///
@@ -64,11 +65,12 @@ public final class Cast: NSObject, ObservableObject {
     /// 
     /// - Parameter configuration: The configuration to apply to the cast.
     public init(configuration: CastConfiguration = .default) {
+        self.configuration = configuration
         currentSession = context.sessionManager.currentCastSession
         connectionState = context.sessionManager.connectionState
         devices = Self.devices(from: context.discoveryManager)
         currentDevice = currentSession?.device.toCastDevice()
-        player = .init(remoteMediaClient: currentSession?.remoteMediaClient)
+        player = .init(remoteMediaClient: currentSession?.remoteMediaClient, configuration: configuration)
 
         super.init()
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -61,7 +61,9 @@ public final class Cast: NSObject, ObservableObject {
     @Published public private(set) var connectionState: GCKConnectionState
 
     /// Default initializer.
-    override public init() {
+    /// 
+    /// - Parameter configuration: The configuration to apply to the cast.
+    public init(configuration: CastConfiguration = .default) {
         currentSession = context.sessionManager.currentCastSession
         connectionState = context.sessionManager.connectionState
         devices = Self.devices(from: context.discoveryManager)

--- a/Sources/Castor/CastAsset.swift
+++ b/Sources/Castor/CastAsset.swift
@@ -30,15 +30,17 @@ public struct CastAsset {
 
     private let kind: Kind
     private let metadata: CastMetadata
+    private let configuration: PlaybackConfiguration
 
     /// A simple asset which can be played directly.
     ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - metadata: The metadata associated with the asset.
+    ///   - configuration: The playback configuration.
     /// - Returns: The asset.
-    public static func simple(url: URL, metadata: CastMetadata) -> Self {
-        .init(kind: .simple(url), metadata: metadata)
+    public static func simple(url: URL, metadata: CastMetadata, configuration: PlaybackConfiguration = .default) -> Self {
+        .init(kind: .simple(url), metadata: metadata, configuration: configuration)
     }
 
     /// A custom asset represented by some identifier..
@@ -47,14 +49,15 @@ public struct CastAsset {
     ///   - identifier: An identifier for the content to be played.
     ///   - metadata: The metadata associated with the asset.
     /// - Returns: The asset.
-    public static func custom(identifier: String, metadata: CastMetadata) -> Self {
-        .init(kind: .custom(identifier), metadata: metadata)
+    public static func custom(identifier: String, metadata: CastMetadata, configuration: PlaybackConfiguration = .default) -> Self {
+        .init(kind: .custom(identifier), metadata: metadata, configuration: configuration)
     }
 
     func rawItem() -> GCKMediaQueueItem {
         let builder = GCKMediaQueueItemBuilder()
         builder.mediaInformation = mediaInformation()
-        builder.autoplay = true
+        builder.autoplay = configuration.autoplay
+        builder.startTime = configuration.startTime.seconds
         return builder.build()
     }
 

--- a/Sources/Castor/CastConfiguration.swift
+++ b/Sources/Castor/CastConfiguration.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+/// A cast configuration.
+///
+/// The configuration controls behaviors set at cast object creation time and that cannot be changed afterwards.
+public struct CastConfiguration {
+    /// The default configuration.
+    public static let `default` = Self()
+
+    /// The forward skip interval in seconds.
+    public let forwardSkipInterval: TimeInterval
+
+    /// The backward skip interval in seconds.
+    public let backwardSkipInterval: TimeInterval
+
+    /// Creates a player configuration.
+    public init(
+        backwardSkipInterval: TimeInterval = 10,
+        forwardSkipInterval: TimeInterval = 10
+    ) {
+        assert(backwardSkipInterval > 0)
+        assert(forwardSkipInterval > 0)
+        self.backwardSkipInterval = backwardSkipInterval
+        self.forwardSkipInterval = forwardSkipInterval
+    }
+
+    /// The skip interval for some direction, in seconds.
+    public func interval(forSkip skip: Skip) -> TimeInterval {
+        switch skip {
+        case .backward:
+            return backwardSkipInterval
+        case .forward:
+            return forwardSkipInterval
+        }
+    }
+}

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -149,6 +149,21 @@ public extension CastPlayer {
             skipForward()
         }
     }
+
+    /// Returns the current item to its default position.
+    ///
+    /// For a livestream supporting DVR the default position corresponds to the live edge.
+    func skipToDefault() {
+        guard let mediaInformation else { return }
+        switch mediaInformation.streamType {
+        case .live:
+            seek(to: seekableTimeRange().end)
+        case .buffered:
+            seek(to: seekableTimeRange().start)
+        default:
+            return
+        }
+    }
 }
 
 extension CastPlayer {

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -104,19 +104,24 @@ public extension CastPlayer {
 }
 
 public extension CastPlayer {
+    private var seekTargetTime: CMTime? {
+        get {
+            targetSeekTimePublisher.value
+        }
+        set {
+            targetSeekTimePublisher.send(newValue)
+        }
+    }
+
     /// Performs a seek to a given time.
     ///
     /// - Parameter time: The time to reach.
     func seek(to time: CMTime) {
-        updateSeekTargetTime(to: time)
+        seekTargetTime = time
         let options = GCKMediaSeekOptions()
         options.interval = time.seconds
         let request = remoteMediaClient.seek(with: options)
         request.delegate = self
-    }
-
-    private func updateSeekTargetTime(to time: CMTime?) {
-        targetSeekTimePublisher.send(time)
     }
 }
 
@@ -163,17 +168,17 @@ extension CastPlayer: GCKRemoteMediaClientListener {
 extension CastPlayer: GCKRequestDelegate {
     // swiftlint:disable:next missing_docs
     public func requestDidComplete(_ request: GCKRequest) {
-        updateSeekTargetTime(to: nil)
+        seekTargetTime = nil
     }
 
     // swiftlint:disable:next missing_docs
     public func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
-        updateSeekTargetTime(to: nil)
+        seekTargetTime = nil
     }
 
     // swiftlint:disable:next missing_docs
     public func request(_ request: GCKRequest, didFailWithError error: GCKError) {
-        updateSeekTargetTime(to: nil)
+        seekTargetTime = nil
     }
 }
 

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -19,10 +19,13 @@ public final class CastPlayer: NSObject, ObservableObject {
     /// The queue managing player items.
     public let queue: CastQueue
 
-    init?(remoteMediaClient: GCKRemoteMediaClient?) {
+    let configuration: CastConfiguration
+
+    init?(remoteMediaClient: GCKRemoteMediaClient?, configuration: CastConfiguration) {
         guard let remoteMediaClient else { return nil }
 
         self.remoteMediaClient = remoteMediaClient
+        self.configuration = configuration
         mediaStatus = remoteMediaClient.mediaStatus
         queue = .init(remoteMediaClient: remoteMediaClient)
 
@@ -127,11 +130,11 @@ public extension CastPlayer {
 
 extension CastPlayer {
     var backwardSkipTime: CMTime {
-        CMTime(seconds: -10, preferredTimescale: 1)
+        CMTime(seconds: -configuration.backwardSkipInterval, preferredTimescale: 1)
     }
 
     var forwardSkipTime: CMTime {
-        CMTime(seconds: 10, preferredTimescale: 1)
+        CMTime(seconds: configuration.forwardSkipInterval, preferredTimescale: 1)
     }
 }
 
@@ -200,13 +203,13 @@ public extension CastPlayer {
     /// Skips backward.
     func skipBackward() {
         let currentTime = seekTargetTime ?? time()
-        seek(to: CMTimeClampToRange(currentTime - .init(value: 10, timescale: 1), range: seekableTimeRange()))
+        seek(to: CMTimeClampToRange(currentTime + backwardSkipTime, range: seekableTimeRange()))
     }
 
     /// Skips forward.
     func skipForward() {
         let currentTime = seekTargetTime ?? time()
-        seek(to: CMTimeClampToRange(currentTime + .init(value: 10, timescale: 1), range: seekableTimeRange()))
+        seek(to: CMTimeClampToRange(currentTime + forwardSkipTime, range: seekableTimeRange()))
     }
 
     /// Skips in a given direction.

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -137,6 +137,18 @@ public extension CastPlayer {
         let currentTime = seekTargetTime ?? time()
         seek(to: CMTimeClampToRange(currentTime + .init(value: 10, timescale: 1), range: seekableTimeRange()))
     }
+
+    /// Skips in a given direction.
+    ///
+    /// - Parameter skip: The skip direction.
+    func skip(_ skip: Skip) {
+        switch skip {
+        case .backward:
+            skipBackward()
+        case .forward:
+            skipForward()
+        }
+    }
 }
 
 extension CastPlayer {

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -114,13 +114,13 @@ public extension CastPlayer {
         let request = remoteMediaClient.seek(with: options)
         request.delegate = self
     }
+
+    private func updateSeekTargetTime(to time: CMTime?) {
+        targetSeekTimePublisher.send(time)
+    }
 }
 
 extension CastPlayer {
-    func updateSeekTargetTime(to time: CMTime?) {
-        targetSeekTimePublisher.send(time)
-    }
-
     private func pulsePublisher(interval: CMTime) -> AnyPublisher<Void, Never> {
         Timer.publish(every: interval.seconds, on: .main, in: .common)
             .autoconnect()

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -125,6 +125,20 @@ public extension CastPlayer {
     }
 }
 
+public extension CastPlayer {
+    /// Skips backward.
+    func skipBackward() {
+        let currentTime = seekTargetTime ?? time()
+        seek(to: CMTimeClampToRange(currentTime - .init(value: 10, timescale: 1), range: seekableTimeRange()))
+    }
+
+    /// Skips forward.
+    func skipForward() {
+        let currentTime = seekTargetTime ?? time()
+        seek(to: CMTimeClampToRange(currentTime + .init(value: 10, timescale: 1), range: seekableTimeRange()))
+    }
+}
+
 extension CastPlayer {
     private func pulsePublisher(interval: CMTime) -> AnyPublisher<Void, Never> {
         Timer.publish(every: interval.seconds, on: .main, in: .common)

--- a/Sources/Castor/PlaybackConfiguration.swift
+++ b/Sources/Castor/PlaybackConfiguration.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+/// A playback configuration.
+public struct PlaybackConfiguration {
+    /// The default configuration.
+    public static let `default` = Self()
+
+    /// The time to start playback at.
+    ///
+    /// When the time is `.invalid`, playback starts at the default position:
+    ///
+    /// - Zero for an on-demand stream.
+    /// - Live edge for a livestream supporting DVR.
+    public let startTime: CMTime
+
+    /// Whether the item should automatically start playback when it becomes the current item in the
+    /// queue. If `false`, the queue will pause when it reaches this item. The default value is
+    /// `true`.
+    public let autoplay: Bool
+
+    /// Creates a playback configuration.
+    public init(startTime: CMTime = .invalid, autoplay: Bool = true) {
+        self.startTime = startTime
+        self.autoplay = autoplay
+    }
+}

--- a/Sources/Castor/Skip.swift
+++ b/Sources/Castor/Skip.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+/// A skip.
+public enum Skip {
+    /// Backward skip.
+    case backward
+
+    /// Forward skip.
+    case forward
+}


### PR DESCRIPTION
## Description

This PR allows us to quickly navigate content backward/forward and to return to the live when watching a livestream in the past.

## Changes made

- Add skip forward/backward APIs, as well as generic API based on skip direction.
- Add skip to live API.
- Add check methods.
- Make intervals configurable.
- Add skip buttons to demo player layout.
- Add start time support to item construction.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
