### PR TITLE
Add playback speed

### DIFF
--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -7,14 +7,6 @@
 import Castor
 import SwiftUI
 
-private struct TimeSlider: View {
-    @ObservedObject var player: CastPlayer
-
-    var body: some View {
-        Slider(value: player.playbackSpeed, in: player.playbackSpeedRange)
-    }
-}
-
 struct CastPlayerView: View {
     @EnvironmentObject private var cast: Cast
 
@@ -22,7 +14,6 @@ struct CastPlayerView: View {
         VStack {
             if let player = cast.player {
                 ControlsView(player: player, device: cast.currentDevice)
-                TimeSlider(player: player)
                 PlaylistView(queue: player.queue)
             }
             else {

--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -14,6 +14,7 @@ struct CastPlayerView: View {
         VStack {
             if let player = cast.player {
                 ControlsView(player: player, device: cast.currentDevice)
+                Slider(value: player.playbackSpeed, in: player.playbackSpeedRange)
                 PlaylistView(queue: player.queue)
             }
             else {

--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -7,6 +7,14 @@
 import Castor
 import SwiftUI
 
+private struct TimeSlider: View {
+    @ObservedObject var player: CastPlayer
+
+    var body: some View {
+        Slider(value: player.playbackSpeed, in: player.playbackSpeedRange)
+    }
+}
+
 struct CastPlayerView: View {
     @EnvironmentObject private var cast: Cast
 
@@ -14,7 +22,7 @@ struct CastPlayerView: View {
         VStack {
             if let player = cast.player {
                 ControlsView(player: player, device: cast.currentDevice)
-                Slider(value: player.playbackSpeed, in: player.playbackSpeedRange)
+                TimeSlider(player: player)
                 PlaylistView(queue: player.queue)
             }
             else {

--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -137,7 +137,11 @@ struct ControlsView: View {
 
     private func controls() -> some View {
         VStack {
-            slider()
+            HStack {
+                slider()
+                Spacer()
+                SettingsMenu(player: player)
+            }
             buttons()
         }
         .padding()

--- a/Demo/Sources/Player/SettingsMenu.swift
+++ b/Demo/Sources/Player/SettingsMenu.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Castor
+import SwiftUI
+
+struct SettingsMenu: View {
+    let player: CastPlayer
+
+    var body: some View {
+        Menu {
+            player.standardSettingsMenu()
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 20))
+                .tint(.accent)
+        }
+        .menuOrder(.fixed)
+    }
+}

--- a/Sources/Castor/CastPlaybackSpeed.swift
+++ b/Sources/Castor/CastPlaybackSpeed.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+final class CastPlaybackSpeed: NSObject {
+    private let remoteMediaClient: GCKRemoteMediaClient
+
+    @Published private(set) var targetValue: Float?
+
+    init(remoteMediaClient: GCKRemoteMediaClient) {
+        self.remoteMediaClient = remoteMediaClient
+    }
+
+    func request(for value: Float) {
+        targetValue = value
+        let request = remoteMediaClient.setPlaybackRate(value)
+        request.delegate = self
+    }
+}
+
+extension CastPlaybackSpeed: GCKRequestDelegate {
+    func requestDidComplete(_ request: GCKRequest) {
+        targetValue = nil
+    }
+}

--- a/Sources/Castor/CastPlayer+SettingsMenu.swift
+++ b/Sources/Castor/CastPlayer+SettingsMenu.swift
@@ -7,7 +7,8 @@
 import SwiftUI
 
 private struct SettingsMenuContent: View {
-    let player: CastPlayer
+    @ObservedObject var player: CastPlayer
+
     let speeds: Set<Float>
     let action: (CastSettingsUpdate) -> Void
 
@@ -21,9 +22,9 @@ private struct SettingsMenuContent: View {
                 action(.playbackSpeed(speed))
             }
         } label: {
-            Label {
+            Button(action: {}) {
                 Text("Playback Speed", bundle: .module, comment: "Playback setting menu title")
-            } icon: {
+                Text("\(player.playbackSpeed.wrappedValue, specifier: "%g×")", comment: "Speed multiplier")
                 Image(systemName: "speedometer")
             }
         }

--- a/Sources/Castor/CastPlayer+SettingsMenu.swift
+++ b/Sources/Castor/CastPlayer+SettingsMenu.swift
@@ -1,0 +1,95 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+private struct SettingsMenuContent: View {
+    let player: CastPlayer
+    let speeds: Set<Float>
+    let action: (CastSettingsUpdate) -> Void
+
+    var body: some View {
+        playbackSpeedMenu()
+    }
+
+    private func playbackSpeedMenu() -> some View {
+        Menu {
+            player.playbackSpeedMenu(speeds: speeds) { speed in
+                action(.playbackSpeed(speed))
+            }
+        } label: {
+            Label {
+                Text("Playback Speed", bundle: .module, comment: "Playback setting menu title")
+            } icon: {
+                Image(systemName: "speedometer")
+            }
+        }
+    }
+}
+
+private struct PlaybackSpeedMenuContent: View {
+    let speeds: Set<Float>
+    let action: (Float) -> Void
+
+    @ObservedObject var player: CastPlayer
+
+    var body: some View {
+        Picker("Playback Speed", selection: selection) {
+            ForEach(playbackSpeeds, id: \.self) { speed in
+                Text("\(speed, specifier: "%g×")", comment: "Speed multiplier").tag(speed)
+            }
+        }
+        .pickerStyle(.inline)
+    }
+
+    private var playbackSpeeds: [Float] {
+        speeds.filter { speed in
+            player.playbackSpeedRange.contains(speed)
+        }
+        .sorted()
+    }
+
+    private var selection: Binding<Float> {
+        .init {
+            player.playbackSpeed.wrappedValue
+        } set: { newValue in
+            player.playbackSpeed.wrappedValue = newValue
+            action(newValue)
+        }
+    }
+}
+
+public extension CastPlayer {
+    /// Returns content for a standard player settings menu.
+    ///
+    /// - Parameters:
+    ///    - speeds: The offered playback speeds.
+    ///    - action: The action to perform when the user interacts with an item from the menu.
+    ///
+    /// The returned view is meant to be used as content of a `Menu`. Using it for any other purpose has undefined
+    /// behavior.
+    func standardSettingsMenu(
+        speeds: Set<Float> = [0.5, 1, 1.25, 1.5, 2],
+        action: @escaping (_ update: CastSettingsUpdate) -> Void = { _ in }
+    ) -> some View {
+        SettingsMenuContent(player: self, speeds: speeds, action: action)
+    }
+
+    /// Returns content for a playback speed menu.
+    ///
+    /// - Parameters:
+    ///    - speeds: The offered playback speeds.
+    ///    - action: The action to perform when the user interacts with an item from the menu.
+    ///
+    /// The returned view is meant to be used as content of a `Menu`. Using it for any other purpose has undefined
+    /// behavior.
+    func playbackSpeedMenu(
+        speeds: Set<Float> = [0.5, 1, 1.25, 1.5, 2],
+        action: @escaping (_ speed: Float) -> Void = { _ in }
+    ) -> some View {
+        PlaybackSpeedMenuContent(speeds: speeds, action: action, player: self)
+    }
+}

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -96,7 +96,7 @@ public extension CastPlayer {
 
     /// The currently allowed playback speed range.
     var playbackSpeedRange: ClosedRange<Float> {
-        0.5...2
+        mediaStatus?.mediaInformation?.streamType == .buffered ? 0.5...2 : 1...1
     }
 
     /// A binding to read and write the current playback speed.

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// A cast player.
 public final class CastPlayer: NSObject, ObservableObject {
     private let remoteMediaClient: GCKRemoteMediaClient
-    private var targetSeekTimePublisher = CurrentValueSubject<CMTime?, Never>(nil)
+    private let seek: CastSeek
 
     @Published private var mediaStatus: GCKMediaStatus?
     @Published private var _playbackSpeed: Float = 1
@@ -27,7 +27,10 @@ public final class CastPlayer: NSObject, ObservableObject {
 
         self.remoteMediaClient = remoteMediaClient
         self.configuration = configuration
+
         mediaStatus = remoteMediaClient.mediaStatus
+
+        seek = .init(remoteMediaClient: remoteMediaClient)
         queue = .init(remoteMediaClient: remoteMediaClient)
 
         super.init()
@@ -139,24 +142,11 @@ public extension CastPlayer {
 }
 
 public extension CastPlayer {
-    private var seekTargetTime: CMTime? {
-        get {
-            targetSeekTimePublisher.value
-        }
-        set {
-            targetSeekTimePublisher.send(newValue)
-        }
-    }
-
     /// Performs a seek to a given time.
     ///
     /// - Parameter time: The time to reach.
     func seek(to time: CMTime) {
-        seekTargetTime = time
-        let options = GCKMediaSeekOptions()
-        options.interval = time.seconds
-        let request = remoteMediaClient.seek(with: options)
-        request.delegate = self
+        seek.request(to: time)
     }
 }
 
@@ -194,7 +184,7 @@ public extension CastPlayer {
     func canSkipForward() -> Bool {
         let seekableTimeRange = seekableTimeRange()
         guard seekableTimeRange.isValidAndNotEmpty else { return false }
-        let currentTime = seekTargetTime ?? time()
+        let currentTime = seek.targetTime ?? time()
         return canSeek(to: currentTime + forwardSkipTime)
     }
 
@@ -234,13 +224,13 @@ public extension CastPlayer {
 public extension CastPlayer {
     /// Skips backward.
     func skipBackward() {
-        let currentTime = seekTargetTime ?? time()
+        let currentTime = seek.targetTime ?? time()
         seek(to: CMTimeClampToRange(currentTime + backwardSkipTime, range: seekableTimeRange()))
     }
 
     /// Skips forward.
     func skipForward() {
-        let currentTime = seekTargetTime ?? time()
+        let currentTime = seek.targetTime ?? time()
         seek(to: CMTimeClampToRange(currentTime + forwardSkipTime, range: seekableTimeRange()))
     }
 
@@ -283,7 +273,7 @@ extension CastPlayer {
 
     private func smoothTimePublisher(interval: CMTime) -> AnyPublisher<CMTime, Never> {
         Publishers.CombineLatest3(
-            targetSeekTimePublisher,
+            seek.$targetTime,
             $mediaStatus,
             pulsePublisher(interval: interval)
         )
@@ -309,23 +299,6 @@ extension CastPlayer: GCKRemoteMediaClientListener {
     // swiftlint:disable:next missing_docs
     public func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
         self.mediaStatus = mediaStatus
-    }
-}
-
-extension CastPlayer: GCKRequestDelegate {
-    // swiftlint:disable:next missing_docs
-    public func requestDidComplete(_ request: GCKRequest) {
-        seekTargetTime = nil
-    }
-
-    // swiftlint:disable:next missing_docs
-    public func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
-        seekTargetTime = nil
-    }
-
-    // swiftlint:disable:next missing_docs
-    public func request(_ request: GCKRequest, didFailWithError error: GCKError) {
-        seekTargetTime = nil
     }
 }
 

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -15,6 +15,7 @@ public final class CastPlayer: NSObject, ObservableObject {
     private var targetSeekTimePublisher = CurrentValueSubject<CMTime?, Never>(nil)
 
     @Published private var mediaStatus: GCKMediaStatus?
+    @Published private var _playbackSpeed: Float = 1
 
     /// The queue managing player items.
     public let queue: CastQueue
@@ -63,6 +64,37 @@ public extension CastPlayer {
     /// Stops.
     func stop() {
         remoteMediaClient.stop()
+    }
+}
+
+public extension CastPlayer {
+    /// The currently applicable playback speed.
+    var effectivePlaybackSpeed: Float {
+        mediaStatus?.playbackRate ?? 1
+    }
+
+    /// The currently allowed playback speed range.
+    var playbackSpeedRange: ClosedRange<Float> {
+        0...1
+    }
+
+    /// A binding to read and write the current playback speed.
+    var playbackSpeed: Binding<Float> {
+        .init {
+            self.effectivePlaybackSpeed
+        } set: { newValue in
+            self.setDesiredPlaybackSpeed(newValue)
+        }
+    }
+
+    /// Sets the desired playback speed.
+    ///
+    /// - Parameter playbackSpeed: The playback speed. The default value is 1.
+    ///
+    /// This value might not be applied immediately or might not be applicable at all. You must check
+    /// `effectivePlaybackSpeed` to obtain the actually applied speed.
+    func setDesiredPlaybackSpeed(_ playbackSpeed: Float) {
+        remoteMediaClient.setPlaybackRate(playbackSpeed)
     }
 }
 

--- a/Sources/Castor/CastSeek.swift
+++ b/Sources/Castor/CastSeek.swift
@@ -16,8 +16,8 @@ final class CastSeek: NSObject {
     init(remoteMediaClient: GCKRemoteMediaClient) {
         self.remoteMediaClient = remoteMediaClient
     }
-    
-    func request(to time: CMTime) {
+
+    func request(for time: CMTime) {
         targetTime = time
         let options = GCKMediaSeekOptions()
         options.interval = time.seconds

--- a/Sources/Castor/CastSeek.swift
+++ b/Sources/Castor/CastSeek.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import CoreMedia
+import GoogleCast
+
+final class CastSeek: NSObject {
+    private let remoteMediaClient: GCKRemoteMediaClient
+
+    @Published private(set) var targetTime: CMTime?
+
+    init(remoteMediaClient: GCKRemoteMediaClient) {
+        self.remoteMediaClient = remoteMediaClient
+    }
+    
+    func request(to time: CMTime) {
+        targetTime = time
+        let options = GCKMediaSeekOptions()
+        options.interval = time.seconds
+        let request = remoteMediaClient.seek(with: options)
+        request.delegate = self
+    }
+}
+
+extension CastSeek: GCKRequestDelegate {
+    func requestDidComplete(_ request: GCKRequest) {
+        targetTime = nil
+    }
+
+    func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
+        targetTime = nil
+    }
+
+    func request(_ request: GCKRequest, didFailWithError error: GCKError) {
+        targetTime = nil
+    }
+}

--- a/Sources/Castor/CastSeek.swift
+++ b/Sources/Castor/CastSeek.swift
@@ -30,12 +30,4 @@ extension CastSeek: GCKRequestDelegate {
     func requestDidComplete(_ request: GCKRequest) {
         targetTime = nil
     }
-
-    func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
-        targetTime = nil
-    }
-
-    func request(_ request: GCKRequest, didFailWithError error: GCKError) {
-        targetTime = nil
-    }
 }

--- a/Sources/Castor/CastSettingsUpdate.swift
+++ b/Sources/Castor/CastSettingsUpdate.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+/// A settings update.
+public enum CastSettingsUpdate {
+    /// Playback speed.
+    case playbackSpeed(Float)
+}

--- a/Sources/Castor/Resources/Localizable.xcstrings
+++ b/Sources/Castor/Resources/Localizable.xcstrings
@@ -1,7 +1,12 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-
+    "%g×" : {
+      "comment" : "Speed multiplier"
+    },
+    "Playback Speed" : {
+      "comment" : "Playback setting menu title"
+    }
   },
   "version" : "1.0"
 }


### PR DESCRIPTION
## Description

This PR allows us to play content at non-standard higher or lower speeds.

## Changes made

- Add playback speed property.
- Add menu helper.
- Integrate in demo player layout.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
