### PR TITLE
Support skips symbols based on player configuration

### DIFF
--- a/Demo/Sources/DemoApp.swift
+++ b/Demo/Sources/DemoApp.swift
@@ -70,7 +70,7 @@ struct DemoApp: App {
                     Label("Settings", systemImage: "gearshape.fill")
                 }
             }
-            .environmentObject(Cast())
+            .environmentObject(Cast(configuration: .standard))
         }
     }
 }

--- a/Demo/Sources/Extensions/CastConfiguration.swift
+++ b/Demo/Sources/Extensions/CastConfiguration.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Castor
+import Foundation
+
+extension CastConfiguration {
+    static var standard: Self {
+        let userDefaults = UserDefaults.standard
+        return .init(
+            backwardSkipInterval: userDefaults.backwardSkipInterval,
+            forwardSkipInterval: userDefaults.forwardSkipInterval
+        )
+    }
+}

--- a/Demo/Sources/Extensions/Image.swift
+++ b/Demo/Sources/Extensions/Image.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+extension Image {
+    static func goBackward(withInterval interval: TimeInterval) -> Self {
+        if let uiImage = UIImage(systemName: "gobackward.\(Int(interval))") {
+            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        }
+        else {
+            return Image(systemName: "gobackward.minus")
+        }
+    }
+
+    static func goForward(withInterval interval: TimeInterval) -> Self {
+        if let uiImage = UIImage(systemName: "goforward.\(Int(interval))") {
+            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        }
+        else {
+            return Image(systemName: "goforward.plus")
+        }
+    }
+}

--- a/Demo/Sources/Extensions/UserDefaults.swift
+++ b/Demo/Sources/Extensions/UserDefaults.swift
@@ -10,6 +10,8 @@ extension UserDefaults {
     enum DemoSettingKey {
         static let receiver = "receiver"
         static let presenterModeEnabled = "presenterModeEnabled"
+        static let backwardSkipInterval = "backwardSkipInterval"
+        static let forwardSkipInterval = "forwardSkipInterval"
     }
 
     @objc dynamic var presenterModeEnabled: Bool {
@@ -18,5 +20,13 @@ extension UserDefaults {
 
     @objc dynamic var receiver: Receiver {
         .init(rawValue: integer(forKey: DemoSettingKey.receiver)) ?? .standard
+    }
+
+    @objc dynamic var backwardSkipInterval: TimeInterval {
+        double(forKey: DemoSettingKey.backwardSkipInterval)
+    }
+
+    @objc dynamic var forwardSkipInterval: TimeInterval {
+        double(forKey: DemoSettingKey.forwardSkipInterval)
     }
 }

--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -26,6 +26,9 @@ struct CastPlayerView: View {
             }
         }
         .animation(.default, value: cast.player)
+        .onAppear {
+            cast.update(configuration: .standard)
+        }
     }
 }
 

--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -26,9 +26,6 @@ struct CastPlayerView: View {
             }
         }
         .animation(.default, value: cast.player)
-        .onAppear {
-            cast.update(configuration: .standard)
-        }
     }
 }
 

--- a/Demo/Sources/Player/ControlsView.swift
+++ b/Demo/Sources/Player/ControlsView.swift
@@ -24,6 +24,7 @@ struct ControlsView: View {
         return formatter
     }()
 
+    @EnvironmentObject private var cast: Cast
     @StateObject private var progressTracker = CastProgressTracker(interval: .init(value: 1, timescale: 10))
     @ObservedObject var player: CastPlayer
     let device: CastDevice?
@@ -153,7 +154,7 @@ private extension ControlsView {
 
     private func skipBackwardButton() -> some View {
         Button(action: player.skipBackward) {
-            Image(systemName: "gobackward.10")
+            Image.goBackward(withInterval: cast.configuration.backwardSkipInterval)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: Self.side)
@@ -184,7 +185,7 @@ private extension ControlsView {
 
     private func skipForwardButton() -> some View {
         Button(action: player.skipForward) {
-            Image(systemName: "goforward.10")
+            Image.goForward(withInterval: cast.configuration.forwardSkipInterval)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: Self.side)

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -9,6 +9,8 @@ import GoogleCast
 import SwiftUI
 
 struct SettingsView: View {
+    @EnvironmentObject private var cast: Cast
+
     @AppStorage(UserDefaults.DemoSettingKey.presenterModeEnabled)
     private var isPresenterModeEnabled = false
 
@@ -45,6 +47,9 @@ struct SettingsView: View {
         }
         .onChange(of: receiver) { _ in exit(0) }
         .navigationTitle("Settings")
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            cast.configuration = .standard
+        }
     }
 
     private func applicationSection() -> some View {

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -15,6 +15,12 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.DemoSettingKey.receiver)
     private var receiver: Receiver = .standard
 
+    @AppStorage(UserDefaults.DemoSettingKey.backwardSkipInterval)
+    private var backwardSkipInterval: TimeInterval = 10
+
+    @AppStorage(UserDefaults.DemoSettingKey.forwardSkipInterval)
+    private var forwardSkipInterval: TimeInterval = 10
+
     private var version: String {
         Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
     }
@@ -33,6 +39,7 @@ struct SettingsView: View {
     var body: some View {
         Form {
             applicationSection()
+            skipsSection()
             receiverSection()
             versionSection()
         }
@@ -48,6 +55,24 @@ struct SettingsView: View {
             }
         } header: {
             Text("Application")
+        }
+    }
+
+    private func skipsSection() -> some View {
+        Section {
+            skipPicker("Backward by", selection: $backwardSkipInterval)
+            skipPicker("Forward by", selection: $forwardSkipInterval)
+        } header: {
+             Text("Skips")
+        }
+    }
+
+    private func skipPicker(_ titleKey: LocalizedStringKey, selection: Binding<TimeInterval>) -> some View {
+        Picker(titleKey, selection: selection) {
+            ForEach([TimeInterval]([5, 7, 10, 15, 30, 45, 60, 75, 90]), id: \.self) { interval in
+                Text("\(Int(interval)) seconds")
+                    .tag(interval)
+            }
         }
     }
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -25,7 +25,7 @@ public final class Cast: NSObject, ObservableObject {
     private var targetDevice: CastDevice?
 
     /// The cast configuration.
-    public let configuration: CastConfiguration
+    public private(set) var configuration: CastConfiguration
 
     /// The current device.
     ///
@@ -105,6 +105,13 @@ public final class Cast: NSObject, ObservableObject {
     /// - Returns: `true` if the given device is casting, `false` otherwise.
     public func isCasting(on device: CastDevice) -> Bool {
         currentDevice == device
+    }
+
+    /// Update the configuration.
+    /// - Parameter configuration: The new configuration.
+    public func update(configuration: CastConfiguration) {
+        self.configuration = configuration
+        player?.update(configuration: configuration)
     }
 }
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -25,7 +25,11 @@ public final class Cast: NSObject, ObservableObject {
     private var targetDevice: CastDevice?
 
     /// The cast configuration.
-    public private(set) var configuration: CastConfiguration
+    public var configuration: CastConfiguration {
+        didSet {
+            player?.configuration = configuration
+        }
+    }
 
     /// The current device.
     ///
@@ -105,13 +109,6 @@ public final class Cast: NSObject, ObservableObject {
     /// - Returns: `true` if the given device is casting, `false` otherwise.
     public func isCasting(on device: CastDevice) -> Bool {
         currentDevice == device
-    }
-
-    /// Update the configuration.
-    /// - Parameter configuration: The new configuration.
-    public func update(configuration: CastConfiguration) {
-        self.configuration = configuration
-        player?.update(configuration: configuration)
     }
 }
 

--- a/Sources/Castor/Cast.swift
+++ b/Sources/Castor/Cast.swift
@@ -23,7 +23,9 @@ public final class Cast: NSObject, ObservableObject {
     }
 
     private var targetDevice: CastDevice?
-    private let configuration: CastConfiguration
+
+    /// The cast configuration.
+    public let configuration: CastConfiguration
 
     /// The current device.
     ///

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -22,7 +22,7 @@ public final class CastPlayer: NSObject, ObservableObject {
     /// The queue managing player items.
     public let queue: CastQueue
 
-    private(set) var configuration: CastConfiguration
+    var configuration: CastConfiguration
 
     init?(remoteMediaClient: GCKRemoteMediaClient?, configuration: CastConfiguration) {
         guard let remoteMediaClient else { return nil }
@@ -40,10 +40,6 @@ public final class CastPlayer: NSObject, ObservableObject {
 
         remoteMediaClient.add(self)
         configurePlaybackSpeedPublisher()
-    }
-
-    func update(configuration: CastConfiguration) {
-        self.configuration = configuration
     }
 
     private func configurePlaybackSpeedPublisher() {

--- a/Sources/Castor/CastPlayer.swift
+++ b/Sources/Castor/CastPlayer.swift
@@ -22,7 +22,7 @@ public final class CastPlayer: NSObject, ObservableObject {
     /// The queue managing player items.
     public let queue: CastQueue
 
-    let configuration: CastConfiguration
+    private(set) var configuration: CastConfiguration
 
     init?(remoteMediaClient: GCKRemoteMediaClient?, configuration: CastConfiguration) {
         guard let remoteMediaClient else { return nil }
@@ -40,6 +40,10 @@ public final class CastPlayer: NSObject, ObservableObject {
 
         remoteMediaClient.add(self)
         configurePlaybackSpeedPublisher()
+    }
+
+    func update(configuration: CastConfiguration) {
+        self.configuration = configuration
     }
 
     private func configurePlaybackSpeedPublisher() {


### PR DESCRIPTION
## Description

This PR allows us, as in [Pillarbox](https://github.com/SRGSSR/pillarbox-apple/pull/1211), to display the correct SF Symbol image based on the cast configuration.

## Changes made

- An extension on Image has been introduced to handle goBackward and goForward images with a configurable time interval.
- Skip intervals can be set from the settings view.
- A method has been added to the `Cast` to allow updating its configuration. Since the `Cast` is initialized only once at the app entry point, the configuration is set once, so we need a way to update it afterwards.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
