### PR TITLE
Provide default values for settings

### DIFF
--- a/Demo/Sources/DemoApp.swift
+++ b/Demo/Sources/DemoApp.swift
@@ -19,6 +19,7 @@ private final class AppDelegate: NSObject, UIApplicationDelegate {
         try? AVAudioSession.sharedInstance().setCategory(.playback)
         configureShowTime()
         configureGoogleCast()
+        UserDefaults.registerDefaults()
         return true
     }
 

--- a/Demo/Sources/Extensions/UserDefaults.swift
+++ b/Demo/Sources/Extensions/UserDefaults.swift
@@ -30,3 +30,13 @@ extension UserDefaults {
         double(forKey: DemoSettingKey.forwardSkipInterval)
     }
 }
+
+extension UserDefaults {
+    static func registerDefaults() {
+        UserDefaults.standard.register(defaults: [
+            DemoSettingKey.presenterModeEnabled: false,
+            DemoSettingKey.backwardSkipInterval: 10,
+            DemoSettingKey.forwardSkipInterval: 10
+        ])
+    }
+}


### PR DESCRIPTION
## Description

This PR provides default values for settings, most notably skip intervals, so that the demo app state is correct when installed for the first time.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
