### PR TITLE
Support repeat modes

### DIFF
--- a/Demo/Sources/Player/CastPlayerView.swift
+++ b/Demo/Sources/Player/CastPlayerView.swift
@@ -14,7 +14,7 @@ struct CastPlayerView: View {
         VStack {
             if let player = cast.player {
                 ControlsView(player: player, device: cast.currentDevice)
-                PlaylistView(queue: player.queue)
+                PlaylistView(player: player, queue: player.queue)
             }
             else {
                 MessageView(message: "Not connected", icon: .system("play.slash.fill"))

--- a/Demo/Sources/Player/PlaylistView.swift
+++ b/Demo/Sources/Player/PlaylistView.swift
@@ -39,6 +39,7 @@ private struct ItemCell: View {
 }
 
 struct PlaylistView: View {
+    @ObservedObject var player: CastPlayer
     @ObservedObject var queue: CastQueue
     @State private var isSelectionPresented = false
 
@@ -86,6 +87,7 @@ private extension PlaylistView {
 
     func managementButtons() -> some View {
         HStack(spacing: 30) {
+            repeatModeButton()
             shuffleButton()
             addButton()
             trashButton()
@@ -98,6 +100,36 @@ private extension PlaylistView {
             Image(systemName: "arrow.right")
         }
         .disabled(!queue.canAdvanceToNextItem())
+    }
+}
+
+private extension PlaylistView {
+    private var repeatModeImageName: String {
+        switch player.repeatMode {
+        case .off:
+            "repeat.circle"
+        case .one:
+            "repeat.1.circle.fill"
+        case .all:
+            "repeat.circle.fill"
+        }
+    }
+
+    private func toggleRepeatMode() {
+        switch player.repeatMode {
+        case .off:
+            player.repeatMode = .all
+        case .one:
+            player.repeatMode = .off
+        case .all:
+            player.repeatMode = .one
+        }
+    }
+
+    func repeatModeButton() -> some View {
+        Button(action: toggleRepeatMode) {
+            Image(systemName: repeatModeImageName)
+        }
     }
 }
 

--- a/Sources/Castor/CastRepeat.swift
+++ b/Sources/Castor/CastRepeat.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+final class CastRepeat: NSObject {
+    private let remoteMediaClient: GCKRemoteMediaClient
+
+    @Published private(set) var targetMode: CastRepeatMode?
+
+    init(remoteMediaClient: GCKRemoteMediaClient) {
+        self.remoteMediaClient = remoteMediaClient
+    }
+
+    func request(for mode: CastRepeatMode) {
+        targetMode = mode
+        let request = remoteMediaClient.queueSetRepeatMode(mode.rawMode())
+        request.delegate = self
+    }
+}
+
+extension CastRepeat: GCKRequestDelegate {
+    func requestDidComplete(_ request: GCKRequest) {
+        targetMode = nil
+    }
+}

--- a/Sources/Castor/CastRepeatMode.swift
+++ b/Sources/Castor/CastRepeatMode.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+/// A mode setting how a player repeats playback of items in its queue.
+public enum CastRepeatMode {
+    /// Disabled.
+    case off
+
+    /// Repeat the current item.
+    case one
+
+    /// Repeat all items.
+    case all
+
+    func rawMode() -> GCKMediaRepeatMode {
+        switch self {
+        case .off:
+            return .off
+        case .one:
+            return .single
+        case .all:
+            return .all
+        }
+    }
+}

--- a/Sources/Castor/CastRepeatMode.swift
+++ b/Sources/Castor/CastRepeatMode.swift
@@ -17,6 +17,19 @@ public enum CastRepeatMode {
     /// Repeat all items.
     case all
 
+    init?(rawMode: GCKMediaRepeatMode) {
+        switch rawMode {
+        case .off:
+            self = .off
+        case .single:
+            self = .one
+        case .all, .allAndShuffle:
+            self = .all
+        default:
+            return nil
+        }
+    }
+
     func rawMode() -> GCKMediaRepeatMode {
         switch self {
         case .off:


### PR DESCRIPTION
## Description

This PR enables us to repeat items played on a receiver.

## Changes made

- Repeat mode API has been added.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
