### PR TITLE
Fix nightly builds

### DIFF
--- a/Scripts/private/deliver-demo.sh
+++ b/Scripts/private/deliver-demo.sh
@@ -12,7 +12,7 @@ function usage {
 function install_tools {
     curl -Ssf https://pkgx.sh | sh &> /dev/null
     set -a
-    eval "$(pkgx +bundle +rsvg-convert +magick)"
+    eval "$(pkgx +ruby@3.3.0 +bundle +rsvg-convert +magick)"
     set +a
 }
 


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- Ruby `3.3.0` has been explicitly set to avoid issue with the last ruby version.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
