### PR TITLE
Restore certificate import

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -16,6 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Add Apple certificate
+        run: |
+          Scripts/private/add-apple-certificate.sh \
+          $RUNNER_TEMP \
+          ${{ secrets.KEYCHAIN_PASSWORD }} \
+          ${{ secrets.APPLE_DEV_CERTIFICATE }} \
+          ${{ secrets.APPLE_DEV_CERTIFICATE_PASSWORD }}
+
       - name: Configure environment
         run: |
           Scripts/private/configure-environment.sh \

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -16,6 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Add Apple certificate
+        run: |
+          Scripts/private/add-apple-certificate.sh \
+          $RUNNER_TEMP \
+          ${{ secrets.KEYCHAIN_PASSWORD }} \
+          ${{ secrets.APPLE_DEV_CERTIFICATE }} \
+          ${{ secrets.APPLE_DEV_CERTIFICATE_PASSWORD }}
+
       - name: Configure environment
         run: |
           Scripts/private/configure-environment.sh \

--- a/Scripts/private/add-apple-certificate.sh
+++ b/Scripts/private/add-apple-certificate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+ROOT_DIR="$1"
+KEYCHAIN_PASSWORD="$2"
+APPLE_CERTIFICATE_BASE64="$3"
+APPLE_CERTIFICATE_PASSWORD="$4"
+
+if [[ -z $ROOT_DIR || -z $KEYCHAIN_PASSWORD || -z $APPLE_CERTIFICATE_BASE64 || -z $APPLE_CERTIFICATE_PASSWORD ]]
+then
+    echo "[!] Usage: $0 <ROOT_DIR> <KEYCHAIN_PASSWORD> <APPLE_CERTIFICATE_BASE64 (base64)> <APPLE_CERTIFICATE_PASSWORD>"
+    exit 1
+fi
+
+KEYCHAIN_PATH="$ROOT_DIR/app-signing.keychain-db"
+APPLE_CERTIFICATE="$ROOT_DIR/certificate.p12"
+
+echo -n "$APPLE_CERTIFICATE_BASE64" | base64 --decode -o "$APPLE_CERTIFICATE"
+
+# Create a temporary keychain (https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners)
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+# Import certificate
+security import "$APPLE_CERTIFICATE" -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12
+# Authorize access to certificate private key
+security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+# Set the default keychain
+security list-keychain -d user -s "$KEYCHAIN_PATH"

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -6,6 +6,18 @@ Continuous integration is performed using GitHub Actions. Worflows require a few
 
 Some information is kept confidential and stored in secrets.
 
+### Apple developer certificate
+
+An Apple developer certificate exported from Xcode, and protected by a password, is required. More information is available from the [GitHub documentation](https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development):
+
+- `APPLE_DEV_CERTIFICATE`: The certificate `p12` file converted to Base64 can be copied to the clipboard with:
+
+    ```shell
+    base64 -i developer_certificate.p12 | pbcopy
+    ```
+
+- `APPLE_DEV_CERTIFICATE_PASSWORD`: The password used to protect the developer certificate.
+
 ### App Store Connect API key
 
 An [App Store Connect API key](https://appstoreconnect.apple.com/access/integrations/api) is required for automatic provisioning:
@@ -22,6 +34,7 @@ An [App Store Connect API key](https://appstoreconnect.apple.com/access/integrat
 ### Other secrets
 
 - `TEAM_ID`: The team ID.
+- `KEYCHAIN_PASSWORD`: An arbitrary password used to create a local keychain to store certificates on GitHub runners. This password is only used to prevent secrets from being easily read from this keychain, should it somehow leak from a GitHub-hosted agent.
 
 ## Environment variables
 


### PR DESCRIPTION
## Description

This PR reverts #108 which we validated too early, based on a sigle nightly delivery that worked. Subsequent deliveries still failed because a [certificate is actually required for archiving](https://github.com/fastlane/fastlane/discussions/19973).
 
## Changes made

- Revert #108 as a whole.
- Restored secrets that were removed from the repository.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
