### PR TITLE
Add an Android TV receiver

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -22,6 +22,7 @@
 		<string>_A12D4273._googlecast._tcp</string>
 		<string>_1AC2931D._googlecast._tcp</string>
 		<string>_EB05B588._googlecast._tcp</string>
+		<string>_5718ACDA._googlecast._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>$(PRODUCT_NAME) uses the local network to discover Google Cast devices on your WiFi network.</string>

--- a/Demo/Sources/DemoApp.swift
+++ b/Demo/Sources/DemoApp.swift
@@ -35,6 +35,7 @@ private final class AppDelegate: NSObject, UIApplicationDelegate {
         let criteria = GCKDiscoveryCriteria(applicationID: UserDefaults.standard.receiver.identifier)
         let options = GCKCastOptions(discoveryCriteria: criteria)
         options.physicalVolumeButtonsWillControlDeviceVolume = true
+        options.launchOptions?.androidReceiverCompatible = true
         GCKCastContext.setSharedInstanceWith(options)
         GCKCastContext.sharedInstance().useDefaultExpandedMediaControls = true
     }

--- a/Demo/Sources/Receiver.swift
+++ b/Demo/Sources/Receiver.swift
@@ -13,6 +13,7 @@ enum Receiver: Int, CaseIterable {
     case drm
     case srgssr
     case amtins
+    case androidTv
 
     var identifier: String {
         switch self {
@@ -24,6 +25,8 @@ enum Receiver: Int, CaseIterable {
             "1AC2931D"
         case .amtins:
             "EB05B588"
+        case .androidTv:
+            "5718ACDA"
         }
     }
 
@@ -37,12 +40,14 @@ enum Receiver: Int, CaseIterable {
             "SRG SSR"
         case .amtins:
             "amtins"
+        case .androidTv:
+            "Android TV"
         }
     }
 
     var isSupportingUrns: Bool {
         switch self {
-        case .srgssr, .amtins:
+        case .srgssr, .amtins, .androidTv:
             true
         default:
             false


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- Receiver `5718ACDA` has been added.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
