### PR TITLE
Fix initial states

### DIFF
--- a/Sources/Castor/Player/CastPlayer+TimePublisher.swift
+++ b/Sources/Castor/Player/CastPlayer+TimePublisher.swift
@@ -19,7 +19,7 @@ extension CastPlayer {
     private func smoothTimePublisher(interval: CMTime) -> AnyPublisher<CMTime, Never> {
         Publishers.CombineLatest3(
             $_targetSeekTime,
-            objectWillChange,
+            objectWillChange.prepend(()),
             pulsePublisher(interval: interval)
         )
         .weakCapture(self)

--- a/Sources/Castor/PropertyWrappers/LazyItemPropertyWrapper.swift
+++ b/Sources/Castor/PropertyWrappers/LazyItemPropertyWrapper.swift
@@ -31,8 +31,8 @@ where Instance: ObservableObject, Instance.ObjectWillChangePublisher == Observab
     init(id: GCKMediaQueueItemID, queue: GCKMediaQueue) {
         self.id = id
         self.queue = queue
+        self.value = queue.item(withID: id, fetchIfNeeded: false)
         super.init()
-        value = queue.item(at: id, fetchIfNeeded: false)
         queue.add(self)        // The delegate is retained.
     }
 

--- a/Sources/Castor/Recipes/DevicesRecipe.swift
+++ b/Sources/Castor/Recipes/DevicesRecipe.swift
@@ -11,7 +11,7 @@ final class DevicesRecipe: NSObject, ReceiverStateRecipe {
 
     private let update: ([CastDevice]) -> Void
 
-    private var devices: [CastDevice] = [] {
+    private var devices: [CastDevice] {
         didSet {
             update(devices)
         }
@@ -19,6 +19,7 @@ final class DevicesRecipe: NSObject, ReceiverStateRecipe {
 
     init(service: GCKDiscoveryManager, update: @escaping ([CastDevice]) -> Void) {
         self.update = update
+        self.devices = Self.status(from: service)
         super.init()
         service.add(self)
         service.startDiscovery()

--- a/Sources/Castor/Recipes/ItemsRecipe.swift
+++ b/Sources/Castor/Recipes/ItemsRecipe.swift
@@ -15,7 +15,7 @@ final class ItemsRecipe: NSObject, MutableReceiverStateRecipe {
     private let update: ([CastPlayerItem]) -> Void
     private var completion: ((Bool) -> Void)?
 
-    private var items: [CastPlayerItem] = [] {
+    private var items: [CastPlayerItem] {
         didSet {
             update(items)
         }
@@ -31,6 +31,7 @@ final class ItemsRecipe: NSObject, MutableReceiverStateRecipe {
     init(service: GCKRemoteMediaClient, update: @escaping ([CastPlayerItem]) -> Void) {
         self.service = service
         self.update = update
+        self.items = Self.status(from: service)
         super.init()
         service.mediaQueue.add(self)        // The delegate is retained.
     }

--- a/Sources/Castor/Recipes/MediaStatusRecipe.swift
+++ b/Sources/Castor/Recipes/MediaStatusRecipe.swift
@@ -14,6 +14,7 @@ final class MediaStatusRecipe: NSObject, ReceiverStateRecipe {
     init(service: GCKRemoteMediaClient, update: @escaping (GCKMediaStatus?) -> Void) {
         self.update = update
         super.init()
+        update(service.mediaStatus)
         service.add(self)
     }
 


### PR DESCRIPTION
## Description

This PR allows us to setup initial states.

## Changes made

- The devices list has been initialized properly.
- The `smoothTimePublisher` has been fixed by forcing `objectWillChange` publisher to publish an initial value. 
- Fix items initialization by calling the right/our API.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
