### PR TITLE
Add TODO to improve cast sync between app windows

### DIFF
--- a/Demo/Sources/DemoApp.swift
+++ b/Demo/Sources/DemoApp.swift
@@ -73,6 +73,7 @@ struct DemoApp: App {
                     Label("Settings", systemImage: "gearshape.fill")
                 }
             }
+            // TODO: Starting with iOS 17 this can be moved on the `WindowGroup` without the need for a local `@State`.
             .environmentObject(Cast(configuration: .standard))
         }
     }


### PR DESCRIPTION
## Description

This PR adds a TODO to later improve status consistency between app windows, when Castor supports iOS 17+. This is not required, which proves the robustness of our implementation, but would lead to immediate synchronization of the status between windows (e.g. toggling the mute state; note that sliders are only synchronized on release, though).

Note that the same effect could be theoretically achieved with a local state in `DemoApp`, passed to all windows as environment object, but due the fact we provide settings for forward/backward intervals, initialized in the app delegate, the app will fail on an assertion because of the order of initialization. To avoid introducing unnecessary complexity, I suggest we keep our current implementation and simply move the modifier later.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
