### PR TITLE
Improve times reported during item transitions

### DIFF
--- a/Sources/Castor/Player/CastPlayer+TimePublisher.swift
+++ b/Sources/Castor/Player/CastPlayer+TimePublisher.swift
@@ -19,13 +19,14 @@ extension CastPlayer {
     private func smoothTimePublisher(interval: CMTime) -> AnyPublisher<CMTime, Never> {
         Publishers.CombineLatest3(
             $_targetSeekTime,
-            objectWillChange.prepend(()),
+            $_mediaStatus,
             pulsePublisher(interval: interval)
         )
         .weakCapture(self)
-        .map { ($0.0, $1) }
-        .map { targetSeekTime, player in
-            targetSeekTime ?? player.time()
+        .map { ($0.0, $0.1, $1) }
+        .map { targetSeekTime, mediaStatus, player in
+            guard let mediaInformation = mediaStatus?.mediaInformation, mediaInformation.streamType != .none else { return .invalid }
+            return targetSeekTime ?? player.time()
         }
         .eraseToAnyPublisher()
     }


### PR DESCRIPTION
## Description

This PR improves times published internally during item transitions, ultimately surfacing at the progress tracker level. When transitioning between items the current time is not immediately updated, resulting in inconsistent intermediate states.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/6393d075-f99d-43cb-a873-91aa620afd73"/> | <video src="https://github.com/user-attachments/assets/eed4be79-b0b0-4730-af98-2beeec38499d"/> | 

## Changes made

Take into account the media status to return invalid times when the stream type is `.none`. Note that `.unknown` means some stream with is being played, in which case returning time information probably makes sense.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
