### PR TITLE
Use volume range provided by the receiver

### DIFF
--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -70,17 +70,17 @@ public final class Cast: NSObject, ObservableObject {
 
     /// The allowed range for volume values.
     public var volumeRange: ClosedRange<Float> {
-        canAdjustVolume ? 0...1 : 0...0
+        currentSession?.traits?.volumeRange ?? 0...0
     }
 
     /// A Boolean indicating whether the volume can be adjusted.
     public var canAdjustVolume: Bool {
-        currentSession?.isFixedVolume() == false
+        currentSession?.isFixedVolume == false
     }
 
     /// A Boolean indicating whether the device can be muted.
     public var canMute: Bool {
-        currentSession?.supportsMuting() == true
+        currentSession?.supportsMuting == true
     }
 
     /// The current device.

--- a/Sources/Castor/Extensions/GCKCastSession.swift
+++ b/Sources/Castor/Extensions/GCKCastSession.swift
@@ -7,11 +7,11 @@
 import GoogleCast
 
 extension GCKCastSession {
-    func supportsMuting() -> Bool {
+    var supportsMuting: Bool {
         traits?.supportsMuting == true
     }
 
-    func isFixedVolume() -> Bool {
+    var isFixedVolume: Bool {
         traits?.isFixedVolume() == true
     }
 }

--- a/Sources/Castor/Extensions/GCKSessionTraits.swift
+++ b/Sources/Castor/Extensions/GCKSessionTraits.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import GoogleCast
+
+extension GCKSessionTraits {
+    var volumeRange: ClosedRange<Float> {
+        minimumVolume...maximumVolume
+    }
+}

--- a/Sources/Castor/Recipes/MutedRecipe.swift
+++ b/Sources/Castor/Recipes/MutedRecipe.swift
@@ -26,7 +26,7 @@ final class MutedRecipe: NSObject, MutableReceiverStateRecipe {
     }
 
     func requestUpdate(to value: Bool, completion: @escaping (Bool) -> Void) -> Bool {
-        guard let session = service.currentCastSession, session.supportsMuting() else { return false }
+        guard let session = service.currentCastSession, session.supportsMuting else { return false }
         self.completion = completion
         let request = session.setDeviceMuted(value)
         request.delegate = self

--- a/Sources/Castor/Recipes/VolumeRecipe.swift
+++ b/Sources/Castor/Recipes/VolumeRecipe.swift
@@ -26,7 +26,7 @@ final class VolumeRecipe: NSObject, MutableReceiverStateRecipe {
     }
 
     func requestUpdate(to value: Float, completion: @escaping (Bool) -> Void) -> Bool {
-        guard let session = service.currentCastSession, !session.isFixedVolume() else { return false }
+        guard let session = service.currentCastSession, !session.isFixedVolume else { return false }
         self.completion = completion
         let request = session.setDeviceVolume(value)
         request.delegate = self


### PR DESCRIPTION
## Description

This PR ensures that the volume range returned by a `Cast` instance matches the range of the receiver.

## Changes made

- Extract volume range from session traits.
- Transform existing cast session state extraction functions into computed properties.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
