### PR TITLE
Use same label for each Dependabot package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
     groups:
       gems:
         patterns:
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
     groups:
       actions:
         patterns:
@@ -23,6 +27,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
     groups:
       packages:
         patterns:


### PR DESCRIPTION
## Description

This PR avoids attaching labels specific to each package ecosystem when opening Dependabot PRs. This setup is consistent with our [Pillarbox](https://github.com/SRGSSR/pillarbox-apple/pull/1243) setup.

## Changes made

- Open all Dependabot PRs with the same `dependencies` label.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
