### PR TITLE
Avoid blurry images for skip buttons

### DIFF
--- a/Demo/Sources/Extensions/Image.swift
+++ b/Demo/Sources/Extensions/Image.swift
@@ -8,8 +8,9 @@ import SwiftUI
 
 extension Image {
     static func goBackward(withInterval interval: TimeInterval) -> Self {
-        if let uiImage = UIImage(systemName: "gobackward.\(Int(interval))") {
-            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        let imageName = "gobackward.\(Int(interval))"
+        if UIImage(systemName: imageName) != nil {
+            return Image(systemName: imageName)
         }
         else {
             return Image(systemName: "gobackward.minus")
@@ -17,8 +18,9 @@ extension Image {
     }
 
     static func goForward(withInterval interval: TimeInterval) -> Self {
-        if let uiImage = UIImage(systemName: "goforward.\(Int(interval))") {
-            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        let imageName = "goforward.\(Int(interval))"
+        if UIImage(systemName: imageName) != nil {
+            return Image(systemName: imageName)
         }
         else {
             return Image(systemName: "goforward.plus")


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- The API `Image(systemName:)` has been preferred to `Image(uiImage:)`

| Previous | Current |
|--------|--------|
| ![Screenshot 2025-06-23 at 10 11 38](https://github.com/user-attachments/assets/d044f19a-df78-4673-809a-0fcc634ca287) | ![Screenshot 2025-06-23 at 10 13 00](https://github.com/user-attachments/assets/940d48d4-9a75-46e2-bb84-ae6ce939d643) | 

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
