### PR TITLE
Transfer session when switching between google cast receivers

### DIFF
--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -5,7 +5,6 @@
 //
 
 import Combine
-import CoreMedia
 import Foundation
 import GoogleCast
 import SwiftUI

--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -20,6 +20,7 @@ public final class Cast: NSObject, ObservableObject {
     weak var delegate: CastDelegate?
 
     private let context = GCKCastContext.sharedInstance()
+    private var targetResumeState: CastResumeState?
 
     @ReceiverState(DevicesRecipe.self)
     private var _devices
@@ -142,19 +143,19 @@ public final class Cast: NSObject, ObservableObject {
     /// Starts a new session with the given device.
     /// - Parameter device: The device to use for this session.
     public func startSession(with device: CastDevice) {
-        currentDevice = device
+        _currentDevice = device
     }
 
     /// Ends the current session and stops casting if one sender device is connected.
     public func endSession() {
-        context.sessionManager.endSession()
+        _currentDevice = nil
     }
 
     /// Check if the given device if currently casting.
     /// - Parameter device: The device.
     /// - Returns: `true` if the given device is casting, `false` otherwise.
     public func isCasting(on device: CastDevice) -> Bool {
-        currentDevice == device
+        _currentDevice == device
     }
 }
 
@@ -168,7 +169,11 @@ extension Cast: @preconcurrency GCKSessionManagerListener {
     public func sessionManager(_ sessionManager: GCKSessionManager, didStart session: GCKCastSession) {
         currentSession = session
         if let player, let delegate {
-            if let resumeState = castable?.castResumeState() {
+            if let resumeState = targetResumeState {
+                player.loadItems(from: resumeState.assets, with: .init(startTime: resumeState.time, startIndex: resumeState.index))
+                targetResumeState = nil
+            }
+            else if let resumeState = castable?.castResumeState() {
                 player.loadItems(from: resumeState.assets, with: .init(startTime: resumeState.time, startIndex: resumeState.index))
             }
             else {
@@ -195,7 +200,12 @@ extension Cast: @preconcurrency GCKSessionManagerListener {
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, willEnd session: GCKCastSession) {
         if let delegate, let resumeState = session.remoteMediaClient?.resumeState(with: delegate) {
-            delegate.castEndSession(with: resumeState)
+            if currentDevice == nil {
+                delegate.castEndSession(with: resumeState)
+            }
+            else {
+                targetResumeState = resumeState
+            }
         }
     }
 

--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -5,6 +5,7 @@
 //
 
 import Combine
+import CoreMedia
 import Foundation
 import GoogleCast
 import SwiftUI
@@ -193,7 +194,7 @@ extension Cast: @preconcurrency GCKSessionManagerListener {
 
     // swiftlint:disable:next missing_docs
     public func sessionManager(_ sessionManager: GCKSessionManager, willEnd session: GCKCastSession) {
-        if let delegate, let resumeState = player?.resumeState(with: delegate) {
+        if let delegate, let resumeState = session.remoteMediaClient?.resumeState(with: delegate) {
             delegate.castEndSession(with: resumeState)
         }
     }

--- a/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
+++ b/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
@@ -8,12 +8,22 @@ import CoreMedia
 import GoogleCast
 
 extension GCKRemoteMediaClient {
-    private static func isValidTimeInterval(_ timeInterval: TimeInterval) -> Bool {
-        GCKIsValidTimeInterval(timeInterval) && timeInterval != .infinity
-    }
-
     func canMakeRequest() -> Bool {
         mediaStatus?.isConnected == true
+    }
+
+    func resumeState(with delegate: CastDelegate) -> CastResumeState? {
+        guard let mediaStatus, let currentIndex = mediaStatus.currentIndex() else {
+            return nil
+        }
+        let assets = mediaStatus.items().compactMap { delegate.castAsset(from: .init(rawMediaInformation: $0.mediaInformation)) }
+        return CastResumeState(assets: assets, index: currentIndex, time: time() - seekableTimeRange().start)
+    }
+}
+
+extension GCKRemoteMediaClient {
+    private static func isValidTimeInterval(_ timeInterval: TimeInterval) -> Bool {
+        GCKIsValidTimeInterval(timeInterval) && timeInterval != .infinity
     }
 
     func time() -> CMTime {
@@ -35,13 +45,5 @@ extension GCKRemoteMediaClient {
         else {
             return .invalid
         }
-    }
-
-    func resumeState(with delegate: CastDelegate) -> CastResumeState? {
-        guard let mediaStatus, let currentIndex = mediaStatus.currentIndex() else {
-            return nil
-        }
-        let assets = mediaStatus.items().compactMap { delegate.castAsset(from: .init(rawMediaInformation: $0.mediaInformation)) }
-        return CastResumeState(assets: assets, index: currentIndex, time: time() - seekableTimeRange().start)
     }
 }

--- a/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
+++ b/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
@@ -4,10 +4,44 @@
 //  License information is available from the LICENSE file.
 //
 
+import CoreMedia
 import GoogleCast
 
 extension GCKRemoteMediaClient {
+    private static func isValidTimeInterval(_ timeInterval: TimeInterval) -> Bool {
+        GCKIsValidTimeInterval(timeInterval) && timeInterval != .infinity
+    }
+
     func canMakeRequest() -> Bool {
         mediaStatus?.isConnected == true
+    }
+
+    func time() -> CMTime {
+        .init(seconds: approximateStreamPosition(), preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+    }
+
+    func seekableTimeRange() -> CMTimeRange {
+        let start = approximateLiveSeekableRangeStart()
+        let end = approximateLiveSeekableRangeEnd()
+        if Self.isValidTimeInterval(start), Self.isValidTimeInterval(end), start != end {
+            return .init(
+                start: .init(seconds: start, preferredTimescale: CMTimeScale(NSEC_PER_SEC)),
+                end: .init(seconds: end, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+            )
+        }
+        else if let streamDuration = mediaStatus?.mediaInformation?.streamDuration, Self.isValidTimeInterval(streamDuration), streamDuration != 0 {
+            return .init(start: .zero, end: .init(seconds: streamDuration, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        }
+        else {
+            return .invalid
+        }
+    }
+
+    func resumeState(with delegate: CastDelegate) -> CastResumeState? {
+        guard let mediaStatus, let currentIndex = mediaStatus.currentIndex() else {
+            return nil
+        }
+        let assets = mediaStatus.items().compactMap { delegate.castAsset(from: .init(rawMediaInformation: $0.mediaInformation)) }
+        return CastResumeState(assets: assets, index: currentIndex, time: time() - seekableTimeRange().start)
     }
 }

--- a/Sources/Castor/Player/CastPlayer+Time.swift
+++ b/Sources/Castor/Player/CastPlayer+Time.swift
@@ -10,30 +10,11 @@ import GoogleCast
 public extension CastPlayer {
     /// Time.
     func time() -> CMTime {
-        .init(seconds: remoteMediaClient.approximateStreamPosition(), preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        remoteMediaClient.time()
     }
 
     /// Seekable time range.
     func seekableTimeRange() -> CMTimeRange {
-        let start = remoteMediaClient.approximateLiveSeekableRangeStart()
-        let end = remoteMediaClient.approximateLiveSeekableRangeEnd()
-        if Self.isValidTimeInterval(start), Self.isValidTimeInterval(end), start != end {
-            return .init(
-                start: .init(seconds: start, preferredTimescale: CMTimeScale(NSEC_PER_SEC)),
-                end: .init(seconds: end, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-            )
-        }
-        else if let streamDuration = mediaInformation?.streamDuration, Self.isValidTimeInterval(streamDuration), streamDuration != 0 {
-            return .init(start: .zero, end: .init(seconds: streamDuration, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
-        }
-        else {
-            return .invalid
-        }
-    }
-}
-
-private extension CastPlayer {
-    static func isValidTimeInterval(_ timeInterval: TimeInterval) -> Bool {
-        GCKIsValidTimeInterval(timeInterval) && timeInterval != .infinity
+        remoteMediaClient.seekableTimeRange()
     }
 }

--- a/Sources/Castor/Player/CastPlayer.swift
+++ b/Sources/Castor/Player/CastPlayer.swift
@@ -79,10 +79,4 @@ public final class CastPlayer: NSObject, ObservableObject {
         __targetSeekTime.bind(to: remoteMediaClient)
         __items.bind(to: remoteMediaClient)
     }
-
-    func resumeState(with delegate: CastDelegate) -> CastResumeState? {
-        guard let mediaStatus = _mediaStatus, let currentIndex = mediaStatus.currentIndex() else { return nil }
-        let assets = mediaStatus.items().compactMap { delegate.castAsset(from: .init(rawMediaInformation: $0.mediaInformation)) }
-        return CastResumeState(assets: assets, index: currentIndex, time: time() - seekableTimeRange().start)
-    }
 }

--- a/Sources/Castor/PropertyWrappers/CurrentDevicePropertyWrapper.swift
+++ b/Sources/Castor/PropertyWrappers/CurrentDevicePropertyWrapper.swift
@@ -39,8 +39,13 @@ where Instance: ObservableObject, Instance.ObjectWillChangePublisher == Observab
     }
 
     private func requestUpdate(to value: CastDevice?) {
-        guard let value, self.value != value else { return }
-        moveSession(from: self.value, to: value)
+        guard self.value != value else { return }
+        if let value {
+            moveSession(from: self.value, to: value)
+        }
+        else {
+            service.endSession()
+        }
         self.value = value
     }
 


### PR DESCRIPTION
## Description

This PR allows to transfer a Google Cast session from a device to another one without breaking the user experience.

## Changes made

- The `CastDelegate` is not notified anymore (`castEndSession` is not called) when the session is about to be transferred.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
