### PR TITLE
Ensure playlist management buttons have the same height

### DIFF
--- a/Sources/Castor/UserInterface/Player/PlaylistView.swift
+++ b/Sources/Castor/UserInterface/Player/PlaylistView.swift
@@ -49,6 +49,16 @@ struct PlaylistView: View {
         .listStyle(.plain)
         .applyInnerMask(height: 5)
     }
+
+    private func largestShape() -> some View {
+        // https://stackoverflow.com/questions/78766259/sf-symbol-replace-animation-size-is-off
+        ZStack {
+            Image(systemName: "repeat.circle")
+            Image(systemName: "shuffle")
+            Image(systemName: "trash")
+        }
+        .hidden()
+    }
 }
 
 private extension PlaylistView {
@@ -78,7 +88,7 @@ private extension PlaylistView {
 private extension PlaylistView {
     func repeatModeButton(style: ButtonStyle) -> some View {
         Button(action: toggleRepeatMode) {
-            Group {
+            ZStack {
                 switch style {
                 case .large:
                     Label("Repeat", systemImage: repeatModeImageName)
@@ -86,6 +96,7 @@ private extension PlaylistView {
                 case .compact:
                     Image(systemName: repeatModeImageName)
                 }
+                largestShape()
             }
             .frame(maxWidth: .infinity)
         }
@@ -96,7 +107,7 @@ private extension PlaylistView {
         Button {
             player.items.shuffle()
         } label: {
-            Group {
+            ZStack {
                 switch style {
                 case .large:
                     Label("Shuffle", systemImage: "shuffle")
@@ -104,6 +115,7 @@ private extension PlaylistView {
                 case .compact:
                     Image(systemName: "shuffle")
                 }
+                largestShape()
             }
             .frame(maxWidth: .infinity)
         }
@@ -114,7 +126,7 @@ private extension PlaylistView {
         Button {
             isDeleteAllPresented.toggle()
         } label: {
-            Group {
+            ZStack {
                 switch style {
                 case .large:
                     Label("Delete all", systemImage: "trash")
@@ -122,6 +134,7 @@ private extension PlaylistView {
                 case .compact:
                     Image(systemName: "trash")
                 }
+                largestShape()
             }
             .frame(maxWidth: .infinity)
         }


### PR DESCRIPTION
## Description

This PR ensures all playlist management buttons (whose SF Symbol-based icons have slightly different heights) have identical heights.

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/b95d43a7-24e2-4ca5-8049-9d560c56c088) | ![after](https://github.com/user-attachments/assets/7aa3ee46-a9a0-432d-9e77-b9c0d4fed130) | 

## Changes made

Self-explanatory. The usual common icon group trick has been applied once more.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
