### PR TITLE
Add link to app settings

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -88,6 +88,9 @@
     "Name" : {
 
     },
+    "Open settings" : {
+
+    },
     "Player" : {
 
     },

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -66,6 +66,10 @@ struct SettingsView: View {
                 Text("Displays touches for presentation purposes.")
                     .font(.footnote)
             }
+            Button(action: openSettings) {
+                Text("Open settings")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         } header: {
             Text("Application")
         }
@@ -175,6 +179,12 @@ private extension SettingsView {
             return
         }
         UIApplication.shared.open(url)
+    }
+}
+
+private extension SettingsView {
+    private func openSettings() {
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds a link to the app settings (in Settings.app), useful to change the preferred app language e.g.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
