### PR TITLE
Fix a crash on macOS app designed for iPad

### DIFF
--- a/Demo/Sources/Application/RootView.swift
+++ b/Demo/Sources/Application/RootView.swift
@@ -21,6 +21,7 @@ struct RootView: View {
         }
         .sheet(item: $router.presented) { destination in
             destination.view()
+                .environmentObject(cast) // FIXME: Only needed when the app is running on macOS (Designed for iPad).
         }
         // TODO: Starting with iOS 17 this can be moved on the `DemoApp` window group.
         .environmentObject(cast)


### PR DESCRIPTION
## Description

This PR fixes a crash related to intermediate sheets in a hierarchy that uses environment objects on an macOS app designed for iPad.

## Changes made

- The `Cast` object has been injected in the intermediate sheet as well.

## Code example

```swift
import Combine
import SwiftUI

class Foo: ObservableObject {
    let bar = "bar"
}

struct ContentView: View {
    @State private var isPresented = false

    var body: some View {
        Button {
            isPresented.toggle()
        } label: {
            Text("Present")
        }
        .sheet(isPresented: $isPresented) {
            InfoView(isPresented: $isPresented)
        }
        .environmentObject(Foo())
    }
}

struct InfoView: View {
    @Binding var isPresented: Bool
    @EnvironmentObject private var foo: Foo

    var body: some View {
        Color.red
            .overlay {
                VStack {
                    Text(foo.bar) // <-- This line causes the crash on macOS app designed for iPad.
                    Button(action: { isPresented.toggle() }) {
                        Text("Dismiss")
                    }
                }
            }
            .sheet(isPresented: .constant(true)) {
                Color.blue
                    .overlay {
                        Text(foo.bar)
                            .onTapGesture {
                                isPresented.toggle()
                            }
                    }
            }
    }
}
````

> [!NOTE]  
> Works well on iOS and macOS.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
