### PR TITLE
Add state observation article

### DIFF
--- a/Sources/Castor/Castor.docc/Articles/state-observation/state-observation-article.md
+++ b/Sources/Castor/Castor.docc/Articles/state-observation/state-observation-article.md
@@ -22,7 +22,7 @@ Here’s a simple example that observes player state to implement a labeled play
 
 ```swift
 struct PlaybackButton: View {
-    @ObservedObject var player: Player
+    @ObservedObject var player: CastPlayer
 
     var body: some View {
         Button(action: player.togglePlayPause) {

--- a/Sources/Castor/Castor.docc/Articles/state-observation/state-observation-article.md
+++ b/Sources/Castor/Castor.docc/Articles/state-observation/state-observation-article.md
@@ -9,4 +9,61 @@ Learn how to observe and respond to state changes.
 
 ## Overview
 
-TBD
+The ``Castor`` framework leverages [Combine](https://developer.apple.com/documentation/combine), [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject), and published properties, allowing SwiftUI views to automatically react to changes in state:
+
+- ``Cast`` manages all aspects of Google Cast, including the device list, the current device, and the connection state.
+- ``CastPlayer`` interacts with a receiver device once a session has been established, handling playback and item management.
+
+### Observe essential states
+
+``Cast`` and ``CastPlayer`` automatically publish essential states, making it straightforward to build device discovery and playback-related UI components with SwiftUI. For example, you can use [`List`](https://developer.apple.com/documentation/swiftui/list) to present available devices or to create a playlist management interface.
+
+Here’s a simple example that observes player state to implement a labeled playback button:
+
+```swift
+struct PlaybackButton: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        Button(action: player.togglePlayPause) {
+            Text(player.shouldPlay ? "Pause" : "Play")
+        }
+    }
+}
+```
+
+### Observe time updates
+
+Accurate time tracking is crucial for playback features like progress bars. However, to prevent excessive layout refreshes, a ``CastPlayer`` does not automatically publish time updates.
+
+In SwiftUI, use a ``CastProgressTracker`` to efficiently manage and observe progress changes. When bound to a player, a progress tracker not only provides automatic progress updates but also allows the user to interactively adjust the progress.
+
+### Use SwiftUI property wrappers wisely
+
+ [Proper use](https://developer.apple.com/documentation/swiftui/model-data) of SwiftUI property wrappers ensures efficient UI updates. Below are common patterns associated with player observation:
+
+1. **Player Neither Owned nor Observed:** Pass the player as a constant:
+
+    ```swift
+    struct Widget: View {
+        let player: CastPlayer
+
+        var body: some View {
+            // Not updated when the player publishes changes
+        }
+    }
+    ```
+
+2. **Player Not Owned but Observed:** Receive the player as an `@ObservedObject`:
+
+    ```swift
+    struct Widget: View {
+        @ObservedObject var player: CastPlayer
+
+        var body: some View {
+            // Updated when the player publishes changes
+        }
+    }
+    ```
+
+> Note: Because you never instantiate a ``CastPlayer`` directly—instead using the instance provided by ``Cast``—you will not typically use patterns such as `@State` or `@StateObject` to own a player.

--- a/Sources/Castor/Player/CastPlayer.swift
+++ b/Sources/Castor/Player/CastPlayer.swift
@@ -9,6 +9,10 @@ import Combine
 import GoogleCast
 
 /// A player used to interact with a Cast receiver device.
+///
+/// You do not instantiate a `CastPlayer` directly. Instead, use a ``Cast`` instance to manage receivers and establish
+/// sessions. Then use the ``Cast/player`` it provides to control playback, receive status updates, access metadata,
+/// and manage items for the current session.
 @MainActor
 public final class CastPlayer: NSObject, ObservableObject {
     let remoteMediaClient: GCKRemoteMediaClient


### PR DESCRIPTION
## Description

This PR adds a state observation article, based on Pillarbox's original article, with adjustments that match Castor specifics (e.g. the fact you never have to own a `CastPlayer` directly).

## Changes made

- Add state observation article.
- Add a bit of context to `CastPlayer` documentation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
