### PR TITLE
Fix CastDelegate lifecycle when no Castable object is provided

### DIFF
--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -190,6 +190,9 @@ extension Cast: @preconcurrency GCKSessionManagerListener {
             resume(from: resumeState)
             delegate?.castStartSession()
         }
+        else {
+            delegate?.castStartSession()
+        }
     }
 
     // swiftlint:disable:next missing_docs


### PR DESCRIPTION
## Description

This PR fixes a lifecycle issue with `CastDelegate`.  
Previously, when only a `CastDelegate` was set (without any `Castable`), the `delegate.start` method was never called. 

This prevented apps from correctly handling Cast session lifecycle events unless a `Castable` was also present, which was not the intended design.

The fix ensures that `CastDelegate` callbacks are consistently invoked, regardless of whether a `Castable` is registered.

## Changes made

- The `CastDelegate` lifecycle has been updated.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
