### PR TITLE
Avoid white shadows in dark mode

### DIFF
--- a/Sources/Castor/UserInterface/CastPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastPlayerView.swift
@@ -76,7 +76,7 @@ private struct _CastPlayerView: View {
     private func artworkImage() -> some View {
         ArtworkImage(url: player.currentAsset?.metadata?.imageUrl(matching: .init(type: .background)))
             .scaleEffect(player.shouldPlay ? 1 : 0.95)
-            .shadow(color: .primary.opacity(0.15), radius: 6, y: 3)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
             .animation(.default, value: player.shouldPlay)
     }
 

--- a/Sources/Castor/UserInterface/Player/ItemCell.swift
+++ b/Sources/Castor/UserInterface/Player/ItemCell.swift
@@ -27,7 +27,7 @@ struct ItemCell: View {
 
     private func artworkImage() -> some View {
         ArtworkImage(url: item.asset?.metadata?.imageUrl(matching: .init(type: .custom, size: .init(width: 45, height: 45))))
-            .shadow(color: .primary.opacity(0.15), radius: 6, y: 3)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
             .frame(height: 45)
     }
 


### PR DESCRIPTION
## Description

This PR avoids setting white shadows to views in dark mode. White shadows make views incorrectly appear as glowing, not elevated, which is a [not what we want](https://uxplanet.org/8-tips-for-dark-theme-design-8dfc2f8f7ab6).

## Changes made

- Use dark shadows in light and dark modes (we could have removed them in dark mode but this would have added code for a largely similar result).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
