### PR TITLE
Remove useless @MainActor

### DIFF
--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -105,9 +105,7 @@ extension Media.`Type`: Hashable {
     }
 }
 
-// TODO: Remove all @MainActor below as of Xcode 26.0 (demo assumes main actor isolation by default)
-
-@MainActor let kHlsUrlMedias: [Media] = [
+let kHlsUrlMedias: [Media] = [
     .init(
         title: "Apple Basic 4:3",
         imageUrl: kAppleImageUrl,
@@ -143,7 +141,7 @@ extension Media.`Type`: Hashable {
     )
 ]
 
-@MainActor let kMP3UrlMedias: [Media] = [
+let kMP3UrlMedias: [Media] = [
     .init(
         title: "Couleur 3",
         metadataType: .musicTrack,
@@ -170,7 +168,7 @@ extension Media.`Type`: Hashable {
     )
 ]
 
-@MainActor let kDashUrlMedias: [Media] = [
+let kDashUrlMedias: [Media] = [
     .init(
         title: "VOD",
         imageUrl: "https://dashif.org/img/dashif-logo-283x100_new.jpg",
@@ -183,7 +181,7 @@ extension Media.`Type`: Hashable {
     )
 ]
 
-@MainActor let kUrnMedias: [Media] = [
+let kUrnMedias: [Media] = [
     .init(
         title: "Horizontal video",
         type: .urn("urn:rts:video:14827306")


### PR DESCRIPTION
## Description

This PR removes all useless `@MainActor` since we are now using **Xcode 26.0**.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
