### PR TITLE
Add missing documentation links

### DIFF
--- a/Sources/Castor/Castor.docc/Extensions/cast-asset-kind-extension.md
+++ b/Sources/Castor/Castor.docc/Extensions/cast-asset-kind-extension.md
@@ -1,0 +1,9 @@
+# ``Castor/CastAsset/Kind``
+
+## Topics
+
+### Creating Asset Kinds
+
+``entity(_:)``
+``identifier(_:)``
+``url(_:configuration:)``

--- a/Sources/Castor/Castor.docc/Extensions/cast-player-extension.md
+++ b/Sources/Castor/Castor.docc/Extensions/cast-player-extension.md
@@ -10,6 +10,7 @@
 - ``insertItem(from:before:)``
 - ``insertItems(from:after:)``
 - ``insertItems(from:before:)``
+- ``items``
 - ``loadItem(from:with:)``
 - ``loadItems(from:with:)``
 - ``move(_:after:)``
@@ -23,13 +24,18 @@
 
 - ``pause()``
 - ``play()``
+- ``repeatMode``
+- ``shouldPlay``
 - ``stop()``
 - ``togglePlayPause()``
 
 ### Observing Playback Properties
 
 - ``currentAsset``
+- ``isActive``
+- ``isBusy``
 - ``state``
+- ``streamType``
 - ``time()``
 
 ### Seeking Through Media

--- a/Sources/Castor/Castor.docc/Extensions/cast-volume-icon-extension.md
+++ b/Sources/Castor/Castor.docc/Extensions/cast-volume-icon-extension.md
@@ -4,7 +4,7 @@
 
 ### Creating an Icon
 
-- ``init(cast:)
+- ``init(cast:)``
 
 ### Getting the Body
 


### PR DESCRIPTION
## Description

This PR fixes a few remaining missing documentation links.

## Changes made

- Organize remaining `CastPlayer` APIs.
- Fix incorrect link.
- Add extension for nested `CastAsset.Kind` type. Note that autocompletion works but DocC does not seem to process this file yet (it might hopefully be able to in the future).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
