### PR TITLE
Add HLS audio DVR example

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -31,9 +31,6 @@
     "Cancel" : {
 
     },
-    "DASH streams" : {
-
-    },
     "DASH URLs" : {
 
     },
@@ -47,9 +44,6 @@
 
     },
     "Forward by" : {
-
-    },
-    "HLS streams" : {
 
     },
     "HLS URLs" : {
@@ -74,9 +68,6 @@
 
     },
     "Made with love in Switzerland" : {
-
-    },
-    "MP3 streams " : {
 
     },
     "MP3 URLs " : {
@@ -137,9 +128,6 @@
 
     },
     "Updating this setting will exit the application." : {
-
-    },
-    "URN-based streams" : {
 
     },
     "URNs" : {

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -138,6 +138,12 @@ let kHlsUrlMedias: [Media] = [
         title: "Tagesschau",
         imageUrl: "https://images.tagesschau.de/image/89045d82-5cd5-46ad-8f91-73911add30ee/AAABh3YLLz0/AAABibBx2rU/20x9-1280/tagesschau-logo-100.jpg",
         type: .url("https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8")
+    ),
+    .init(
+        title: "Couleur 3",
+        metadataType: .musicTrack,
+        imageUrl: "https://img.rts.ch/audio/2010/image/924h3y-25865853.image?w=640&h=640",
+        type: .url("https://stxt-audiostreaming.akamaized.net/hls/live/2117380/couleur3/master.m3u8")
     )
 ]
 

--- a/Demo/Sources/Player/PlaylistSelectionView.swift
+++ b/Demo/Sources/Player/PlaylistSelectionView.swift
@@ -52,11 +52,11 @@ struct PlaylistSelectionView: View {
 
     private func list() -> some View {
         List(selection: $selectedMedias) {
-            section("HLS streams", medias: kHlsUrlMedias)
-            section("MP3 streams ", medias: kMP3UrlMedias)
-            section("DASH streams", medias: kDashUrlMedias)
+            section("HLS URLs", medias: kHlsUrlMedias)
+            section("MP3 URLs ", medias: kMP3UrlMedias)
+            section("DASH URLs", medias: kDashUrlMedias)
             if UserDefaults.standard.receiver.isSrgSsrReceiver {
-                section("URN-based streams", medias: kUrnMedias)
+                section("URNs", medias: kUrnMedias)
             }
         }
     }


### PR DESCRIPTION
## Description

This PR adds an HLS audio DVR example to the Castor demo.

## Changes made

- Add example.
- Align section header titles between content adding and example views.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
