### PR TITLE
Add icon to disconnected message

### DIFF
--- a/Sources/Castor/UserInterface/CastPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastPlayerView.swift
@@ -167,6 +167,12 @@ public struct CastPlayerView: View {
     }
 
     private func disconnectedView() -> some View {
-        Text("Disconnected", bundle: .module, comment: "Disconnected from a receiver")
+        UnavailableView {
+            Label {
+                Text("Disconnected", bundle: .module, comment: "Disconnected from a receiver")
+            } icon: {
+                Image("google.cast", bundle: .module)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR enhances the disconnect status message displayed when a Google Cast session is abruptly disconnected (e.g. by stealing the receiver with Google Cast-enabled app).

| Before | After |
|--------|--------|
| <img width="567" height="1082" alt="Before" src="https://github.com/user-attachments/assets/54b874cb-6ea0-48ee-936f-b0a99dc41b70" /> | <img width="567" height="1082" alt="After" src="https://github.com/user-attachments/assets/15ff81b5-4d43-4e55-a2fb-fc977af4faa3" /> | 

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
