### PR TITLE
Transfer playback parameters between sender and receiver

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -13,6 +13,9 @@
     "Add content" : {
 
     },
+    "All" : {
+
+    },
     "amtins" : {
 
     },
@@ -82,6 +85,12 @@
     "No content" : {
 
     },
+    "Off" : {
+
+    },
+    "One" : {
+
+    },
     "Open settings" : {
 
     },
@@ -98,6 +107,9 @@
 
     },
     "Receiver" : {
+
+    },
+    "Repeat" : {
 
     },
     "Settings" : {

--- a/Demo/Sources/Extensions/CastRepeatMode.swift
+++ b/Demo/Sources/Extensions/CastRepeatMode.swift
@@ -6,8 +6,20 @@
 
 import Castor
 import PillarboxPlayer
+import SwiftUI
 
 extension CastRepeatMode {
+    var name: LocalizedStringKey {
+        switch self {
+        case .off:
+            "Off"
+        case .one:
+            "One"
+        case .all:
+            "All"
+        }
+    }
+
     init(from repeatMode: RepeatMode) {
         switch repeatMode {
         case .off:

--- a/Demo/Sources/Extensions/CastRepeatMode.swift
+++ b/Demo/Sources/Extensions/CastRepeatMode.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Castor
+import PillarboxPlayer
+
+extension CastRepeatMode {
+    init(from repeatMode: RepeatMode) {
+        switch repeatMode {
+        case .off:
+            self = .off
+        case .one:
+            self = .one
+        case .all:
+            self = .all
+        }
+    }
+}

--- a/Demo/Sources/Extensions/RepeatMode.swift
+++ b/Demo/Sources/Extensions/RepeatMode.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Castor
+import PillarboxPlayer
+
+extension RepeatMode {
+    init(from repeatMode: CastRepeatMode) {
+        switch repeatMode {
+        case .off:
+            self = .off
+        case .one:
+            self = .one
+        case .all:
+            self = .all
+        }
+    }
+}

--- a/Demo/Sources/Extensions/RepeatMode.swift
+++ b/Demo/Sources/Extensions/RepeatMode.swift
@@ -6,8 +6,20 @@
 
 import Castor
 import PillarboxPlayer
+import SwiftUI
 
 extension RepeatMode {
+    var name: LocalizedStringKey {
+        switch self {
+        case .off:
+            "Off"
+        case .one:
+            "One"
+        case .all:
+            "All"
+        }
+    }
+
     init(from repeatMode: CastRepeatMode) {
         switch repeatMode {
         case .off:

--- a/Demo/Sources/Player/LocalPlaybackView.swift
+++ b/Demo/Sources/Player/LocalPlaybackView.swift
@@ -124,6 +124,46 @@ private struct LocalErrorView: View {
     }
 }
 
+private struct LocalSettingsMenu: View {
+    let player: Player
+
+    var body: some View {
+        Menu {
+            player.standardSettingsMenu()
+            LocalRepeatModeMenu(player: player)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 20))
+                .tint(.white)
+        }
+        .menuOrder(.fixed)
+    }
+}
+
+private struct LocalRepeatModeMenu: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        Menu {
+            Picker(selection: $player.repeatMode) {
+                // FIXME: Use CaseIterable
+                ForEach([RepeatMode.off, .one, .all], id: \.self) { mode in
+                    Text(mode.name).tag(mode)
+                }
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Button(action: {}) {
+                Text("Repeat")
+                Text(player.repeatMode.name)
+                Image(systemName: "repeat.circle")
+            }
+        }
+    }
+}
+
 struct LocalPlaybackView: View {
     @ObservedObject var model: PlayerViewModel
     @ObservedObject var player: Player
@@ -194,21 +234,10 @@ struct LocalPlaybackView: View {
     private func bottomBar() -> some View {
         HStack {
             LocalTimeBar(player: player)
-            settingsButton()
+            LocalSettingsMenu(player: player)
         }
         .padding()
         .frame(maxHeight: .infinity, alignment: .bottom)
-    }
-
-    private func settingsButton() -> some View {
-        Menu {
-            player.standardSettingsMenu()
-        } label: {
-            Image(systemName: "ellipsis.circle")
-                .font(.system(size: 20))
-                .tint(.white)
-        }
-        .menuOrder(.fixed)
     }
 
     private func playlist() -> some View {

--- a/Demo/Sources/Player/LocalPlaybackView.swift
+++ b/Demo/Sources/Player/LocalPlaybackView.swift
@@ -146,8 +146,7 @@ private struct LocalRepeatModeMenu: View {
     var body: some View {
         Menu {
             Picker(selection: $player.repeatMode) {
-                // FIXME: Use CaseIterable
-                ForEach([RepeatMode.off, .one, .all], id: \.self) { mode in
+                ForEach(RepeatMode.allCases, id: \.self) { mode in
                     Text(mode.name).tag(mode)
                 }
             } label: {

--- a/Demo/Sources/Player/LocalPlaybackView.swift
+++ b/Demo/Sources/Player/LocalPlaybackView.swift
@@ -154,11 +154,8 @@ private struct LocalRepeatModeMenu: View {
             }
             .pickerStyle(.inline)
         } label: {
-            Button(action: {}) {
-                Text("Repeat")
-                Text(player.repeatMode.name)
-                Image(systemName: "repeat.circle")
-            }
+            Label("Repeat", systemImage: "repeat.circle")
+            Text(player.repeatMode.name)
         }
     }
 }

--- a/Demo/Sources/Player/PlayerViewModel.swift
+++ b/Demo/Sources/Player/PlayerViewModel.swift
@@ -77,8 +77,8 @@ extension PlayerViewModel: Castable {
             entries = []
         }
         let options = CastLoadOptions(
-            startTime: time(),
             startIndex: currentIndex() ?? 0,
+            startTime: time(),
             shouldPlay: player.shouldPlay,
             playbackSpeed: player.playbackSpeed,
             repeatMode: .init(from: player.repeatMode)

--- a/Demo/Sources/Player/PlayerViewModel.swift
+++ b/Demo/Sources/Player/PlayerViewModel.swift
@@ -76,7 +76,14 @@ extension PlayerViewModel: Castable {
         defer {
             entries = []
         }
-        guard var resumeState = CastResumeState(assets: castAssets(), index: currentIndex(), time: time()) else {
+        let options = CastLoadOptions(
+            startTime: time(),
+            startIndex: currentIndex() ?? 0,
+            shouldPlay: player.shouldPlay,
+            playbackSpeed: player.effectivePlaybackSpeed,
+            repeatMode: .init(from: player.repeatMode)
+        )
+        guard var resumeState = CastResumeState(assets: castAssets(), options: options) else {
             return nil
         }
         resumeState.setMediaSelection(from: player)
@@ -107,11 +114,14 @@ extension PlayerViewModel: Castable {
     }
 
     private func resume(from resumeState: CastResumeState?) {
-        guard let resumeState, let entry = entries[safeIndex: resumeState.index] else { return }
-        let startTime = resumeState.time.isValid ? resumeState.time : .zero
+        guard let resumeState else { return }
+        let options = resumeState.options
+        guard let entry = entries[safeIndex: options.startIndex] else { return }
+        let startTime = options.startTime.isValid ? options.startTime : .zero
         player.setMediaSelection(from: resumeState)
+        player.setDesiredPlaybackSpeed(options.playbackSpeed)
+        player.shouldPlay = options.shouldPlay
         player.resume(at(startTime), in: entry.item)
-        play()
     }
 
     private func currentIndex() -> Int? {

--- a/Demo/Sources/Player/PlayerViewModel.swift
+++ b/Demo/Sources/Player/PlayerViewModel.swift
@@ -121,6 +121,7 @@ extension PlayerViewModel: Castable {
         player.setMediaSelection(from: resumeState)
         player.setDesiredPlaybackSpeed(options.playbackSpeed)
         player.shouldPlay = options.shouldPlay
+        player.repeatMode = .init(from: options.repeatMode)
         player.resume(at(startTime), in: entry.item)
     }
 

--- a/Demo/Sources/Player/PlayerViewModel.swift
+++ b/Demo/Sources/Player/PlayerViewModel.swift
@@ -80,7 +80,7 @@ extension PlayerViewModel: Castable {
             startTime: time(),
             startIndex: currentIndex() ?? 0,
             shouldPlay: player.shouldPlay,
-            playbackSpeed: player.effectivePlaybackSpeed,
+            playbackSpeed: player.playbackSpeed,
             repeatMode: .init(from: player.repeatMode)
         )
         guard var resumeState = CastResumeState(assets: castAssets(), options: options) else {
@@ -118,10 +118,10 @@ extension PlayerViewModel: Castable {
         let options = resumeState.options
         guard let entry = entries[safeIndex: options.startIndex] else { return }
         let startTime = options.startTime.isValid ? options.startTime : .zero
-        player.setMediaSelection(from: resumeState)
-        player.setDesiredPlaybackSpeed(options.playbackSpeed)
         player.shouldPlay = options.shouldPlay
+        player.playbackSpeed = options.playbackSpeed
         player.repeatMode = .init(from: options.repeatMode)
+        player.setMediaSelection(from: resumeState)
         player.resume(at(startTime), in: entry.item)
     }
 

--- a/Demo/Sources/Player/RemotePlaybackView.swift
+++ b/Demo/Sources/Player/RemotePlaybackView.swift
@@ -98,11 +98,8 @@ private struct RemoteRepeatModeMenu: View {
             }
             .pickerStyle(.inline)
         } label: {
-            Button(action: {}) {
-                Text("Repeat")
-                Text(player.repeatMode.name)
-                Image(systemName: "repeat.circle")
-            }
+            Label("Repeat", systemImage: "repeat.circle")
+            Text(player.repeatMode.name)
         }
     }
 }

--- a/Demo/Sources/Player/RemotePlaybackView.swift
+++ b/Demo/Sources/Player/RemotePlaybackView.swift
@@ -68,6 +68,45 @@ private struct RemoteTimeBar: View {
     }
 }
 
+private struct RemoteSettingsMenu: View {
+    let player: CastPlayer
+
+    var body: some View {
+        Menu {
+            player.standardSettingsMenu()
+            RemoteRepeatModeMenu(player: player)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 20))
+                .tint(.white)
+        }
+        .menuOrder(.fixed)
+    }
+}
+
+private struct RemoteRepeatModeMenu: View {
+    @ObservedObject var player: CastPlayer
+
+    var body: some View {
+        Menu {
+            Picker(selection: $player.repeatMode) {
+                ForEach(CastRepeatMode.allCases, id: \.self) { mode in
+                    Text(mode.name).tag(mode)
+                }
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Button(action: {}) {
+                Text("Repeat")
+                Text(player.repeatMode.name)
+                Image(systemName: "repeat.circle")
+            }
+        }
+    }
+}
+
 struct RemotePlaybackView: View {
     @ObservedObject var player: CastPlayer
 
@@ -117,21 +156,10 @@ struct RemotePlaybackView: View {
     private func bottomBar() -> some View {
         HStack {
             RemoteTimeBar(player: player)
-            settingsButton()
+            RemoteSettingsMenu(player: player)
         }
         .padding()
         .frame(maxHeight: .infinity, alignment: .bottom)
-    }
-
-    private func settingsButton() -> some View {
-        Menu {
-            player.standardSettingsMenu()
-        } label: {
-            Image(systemName: "ellipsis.circle")
-                .font(.system(size: 20))
-                .tint(.white)
-        }
-        .menuOrder(.fixed)
     }
 
     private func playlist() -> some View {

--- a/Package.resolved
+++ b/Package.resolved
@@ -70,7 +70,7 @@
       "location" : "https://github.com/SRGSSR/pillarbox-apple",
       "state" : {
         "branch" : "main",
-        "revision" : "a309006d7299a77befe65db8393992a048b740ea"
+        "revision" : "9c9a4e48de0c418662bb2b6be01ddcd61f540be0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -70,7 +70,7 @@
       "location" : "https://github.com/SRGSSR/pillarbox-apple",
       "state" : {
         "branch" : "main",
-        "revision" : "73c367f1431ceddac3f0806ac5cb602e233be66d"
+        "revision" : "a309006d7299a77befe65db8393992a048b740ea"
       }
     },
     {

--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -61,7 +61,7 @@ public final class Cast: NSObject, ObservableObject {
             _isMuted || _volume == 0
         }
         set {
-            guard _isMuted != newValue || volume == 0 else { return }
+            guard canMute, _isMuted != newValue || volume == 0 else { return }
             _isMuted = newValue
             if !newValue, volume == 0 {
                 volume = 0.1
@@ -77,7 +77,7 @@ public final class Cast: NSObject, ObservableObject {
             _volume
         }
         set {
-            guard _volume != newValue else { return }
+            guard canAdjustVolume, _volume != newValue, volumeRange.contains(newValue) else { return }
             _volume = newValue
         }
     }

--- a/Sources/Castor/Cast/Cast.swift
+++ b/Sources/Castor/Cast/Cast.swift
@@ -236,7 +236,7 @@ extension Cast: @preconcurrency GCKSessionManagerListener {
 
     private func resume(from state: CastResumeState) {
         guard let player else { return }
-        player.loadItems(from: state.assets, with: .init(startTime: state.time, startIndex: state.index))
+        player.loadItems(from: state.assets, with: state.options)
         state.mediaSelectionCharacteristics.forEach { characteristic in
             if let language = state.mediaSelectionLanguage(for: characteristic) {
                 player.setMediaSelectionPreference(.on(languages: language), for: characteristic)

--- a/Sources/Castor/Castor.docc/Articles/playback-speed-article.md
+++ b/Sources/Castor/Castor.docc/Articles/playback-speed-article.md
@@ -16,8 +16,6 @@ Playback speed is part of the essential properties automatically published by a 
 
 To adjust the playback speed programmatically, use the ``CastPlayer/playbackSpeed`` property. You can retrieve the available speed range with ``CastPlayer/playbackSpeedRange``.
 
-> Tip: For custom user interfaces built in SwiftUI, use ``CastPlayer/playbackSpeed``. This provides a binding to the current playback speed, ensuring seamless integration with SwiftUI views.
-
 ### Provide speed controls
 
 When building a playback user interface, one of the most common requirements is to provide users with the ability to change the playback speed.

--- a/Sources/Castor/Castor.docc/Extensions/cast-load-options-extension.md
+++ b/Sources/Castor/Castor.docc/Extensions/cast-load-options-extension.md
@@ -4,7 +4,7 @@
 
 ### Creating Options
 
-- ``init(startTime:startIndex:shouldPlay:playbackSpeed:repeatMode:)``
+- ``init(startIndex:startTime:shouldPlay:playbackSpeed:repeatMode:)``
 
 ### Reading Options
 

--- a/Sources/Castor/Castor.docc/Extensions/cast-load-options-extension.md
+++ b/Sources/Castor/Castor.docc/Extensions/cast-load-options-extension.md
@@ -4,4 +4,12 @@
 
 ### Creating Options
 
-- ``init(startTime:startIndex:)``
+- ``init(startTime:startIndex:shouldPlay:playbackSpeed:repeatMode:)``
+
+### Reading Options
+
+- ``playbackSpeed``
+- ``repeatMode``
+- ``shouldPlay``
+- ``startIndex``
+- ``startTime``

--- a/Sources/Castor/Castor.docc/Extensions/cast-resume-state-extension.md
+++ b/Sources/Castor/Castor.docc/Extensions/cast-resume-state-extension.md
@@ -4,10 +4,12 @@
 
 ### Creating a Resume State
 
-- ``init(assets:index:time:)``
+- ``init(assets:options:)``
+
+### Reading a State
+
 - ``assets``
-- ``index``
-- ``time``
+- ``options``
 
 ### Managing Media Selection
 

--- a/Sources/Castor/Extensions/GCKMediaStatus.swift
+++ b/Sources/Castor/Extensions/GCKMediaStatus.swift
@@ -11,6 +11,10 @@ extension GCKMediaStatus {
         queueItemCount != 0
     }
 
+    var shouldPlay: Bool {
+        [.playing, .buffering, .loading].contains(playerState)
+    }
+
     func items() -> [GCKMediaQueueItem] {
         (0..<queueItemCount).compactMap { queueItem(at: $0) }
     }

--- a/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
+++ b/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
@@ -20,7 +20,14 @@ extension GCKRemoteMediaClient {
         guard let mediaStatus else { return nil }
         let resumeItems = Self.resumeItems(from: mediaStatus)
         let index = resumeItems.firstIndex { $0.item.itemID == mediaStatus.currentItemID }
-        guard var resumeState = CastResumeState(assets: resumeItems.map(\.asset), index: index, time: time() - seekableTimeRange().start) else {
+        let options = CastLoadOptions(
+            startTime: time() - seekableTimeRange().start,
+            startIndex: index ?? 0,
+            shouldPlay: mediaStatus.shouldPlay,
+            playbackSpeed: mediaStatus.playbackRate,
+            repeatMode: .init(rawMode: mediaStatus.queueRepeatMode) ?? .off
+        )
+        guard var resumeState = CastResumeState(assets: resumeItems.map(\.asset), options: options) else {
             return nil
         }
         mediaStatus.activeTracks().forEach { track in

--- a/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
+++ b/Sources/Castor/Extensions/GCKRemoteMediaClient.swift
@@ -21,8 +21,8 @@ extension GCKRemoteMediaClient {
         let resumeItems = Self.resumeItems(from: mediaStatus)
         let index = resumeItems.firstIndex { $0.item.itemID == mediaStatus.currentItemID }
         let options = CastLoadOptions(
-            startTime: time() - seekableTimeRange().start,
             startIndex: index ?? 0,
+            startTime: time() - seekableTimeRange().start,
             shouldPlay: mediaStatus.shouldPlay,
             playbackSpeed: mediaStatus.playbackRate,
             repeatMode: .init(rawMode: mediaStatus.queueRepeatMode) ?? .off

--- a/Sources/Castor/Player/CastPlayer+Items.swift
+++ b/Sources/Castor/Player/CastPlayer+Items.swift
@@ -28,7 +28,19 @@ public extension CastPlayer {
     ///   - assets: The assets to load as player items.
     ///   - options: The options to use when loading.
     func loadItems(from assets: [CastAsset], with options: CastLoadOptions = .init()) {
-        remoteMediaClient.queueLoad(Self.rawItems(from: assets), with: options.rawOptions)
+        let queueDataBuilder = GCKMediaQueueDataBuilder(queueType: .generic)
+        queueDataBuilder.items = Self.rawItems(from: assets)
+        queueDataBuilder.startIndex = UInt(options.startIndex)
+        queueDataBuilder.repeatMode = options.repeatMode.rawMode()
+
+        let loadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
+        loadRequestDataBuilder.queueData = queueDataBuilder.build()
+        loadRequestDataBuilder.autoplay = NSNumber(booleanLiteral: options.shouldPlay)
+        loadRequestDataBuilder.playbackRate = options.playbackSpeed
+        if options.startTime.isValid {
+            loadRequestDataBuilder.startTime = options.startTime.seconds
+        }
+        remoteMediaClient.loadMedia(with: loadRequestDataBuilder.build())
     }
 
     /// Loads a player item from the specified asset and starts playback.

--- a/Sources/Castor/Player/CastPlayer+Items.swift
+++ b/Sources/Castor/Player/CastPlayer+Items.swift
@@ -35,7 +35,7 @@ public extension CastPlayer {
 
         let loadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
         loadRequestDataBuilder.queueData = queueDataBuilder.build()
-        loadRequestDataBuilder.autoplay = NSNumber(booleanLiteral: options.shouldPlay)
+        loadRequestDataBuilder.autoplay = .init(value: options.shouldPlay)
         loadRequestDataBuilder.playbackRate = options.playbackSpeed
         if options.startTime.isValid {
             loadRequestDataBuilder.startTime = options.startTime.seconds

--- a/Sources/Castor/Player/CastPlayer+Playback.swift
+++ b/Sources/Castor/Player/CastPlayer+Playback.swift
@@ -6,6 +6,8 @@
 
 public extension CastPlayer {
     /// A Boolean value that indicates whether the player should automatically play content when possible.
+    ///
+    /// > Note: Use ``CastLoadOptions`` to configure behavior when loading items.
     var shouldPlay: Bool {
         get {
             _shouldPlay

--- a/Sources/Castor/Player/CastPlayer+PlaybackSpeed.swift
+++ b/Sources/Castor/Player/CastPlayer+PlaybackSpeed.swift
@@ -16,7 +16,7 @@ public extension CastPlayer {
             _playbackSpeed
         }
         set {
-            _playbackSpeed = newValue
+            _playbackSpeed = newValue.clamped(to: playbackSpeedRange)
         }
     }
 }

--- a/Sources/Castor/Player/CastPlayer+PlaybackSpeed.swift
+++ b/Sources/Castor/Player/CastPlayer+PlaybackSpeed.swift
@@ -11,6 +11,8 @@ public extension CastPlayer {
     }
 
     /// The playback speed currently in effect.
+    ///
+    /// > Note: Use ``CastLoadOptions`` to configure behavior when loading items.
     var playbackSpeed: Float {
         get {
             _playbackSpeed

--- a/Sources/Castor/Player/CastPlayer+SettingsMenu.swift
+++ b/Sources/Castor/Player/CastPlayer+SettingsMenu.swift
@@ -90,11 +90,12 @@ private struct SettingsMenuContent: View {
                 action(.playbackSpeed(speed))
             }
         } label: {
-            Button(action: {}) {
+            Label {
                 Text("Playback Speed", bundle: .module, comment: "Playback setting menu title")
-                Text("\(player.playbackSpeed, specifier: "%g×")", bundle: .module, comment: "Speed multiplier")
+            } icon: {
                 Image(systemName: "speedometer")
             }
+            Text("\(player.playbackSpeed, specifier: "%g×")", bundle: .module, comment: "Speed multiplier")
         }
     }
 
@@ -102,11 +103,12 @@ private struct SettingsMenuContent: View {
         Menu {
             mediaSelectionMenuContent(characteristic: .audible)
         } label: {
-            Button(action: {}) {
+            Label {
                 Text("Audio", bundle: .module, comment: "Playback setting menu title")
-                Text(player.selectedMediaOption(for: .audible).displayName)
+            } icon: {
                 Image(systemName: "waveform.circle")
             }
+            Text(player.selectedMediaOption(for: .audible).displayName)
         }
     }
 
@@ -114,11 +116,12 @@ private struct SettingsMenuContent: View {
         Menu {
             mediaSelectionMenuContent(characteristic: .legible)
         } label: {
-            Button(action: {}) {
+            Label {
                 Text("Subtitles", bundle: .module, comment: "Playback setting menu title")
-                Text(player.selectedMediaOption(for: .legible).displayName)
+            } icon: {
                 Image(systemName: "captions.bubble")
             }
+            Text(player.selectedMediaOption(for: .legible).displayName)
         }
     }
 

--- a/Sources/Castor/Player/CastPlayer.swift
+++ b/Sources/Castor/Player/CastPlayer.swift
@@ -57,6 +57,8 @@ public final class CastPlayer: NSObject, ObservableObject {
     }
 
     /// The mode that determines how the player repeats playback of items in its queue.
+    ///
+    /// > Note: Use ``CastLoadOptions`` to configure behavior when loading items.
     public var repeatMode: CastRepeatMode {
         get {
             _repeatMode

--- a/Sources/Castor/Recipes/MutedRecipe.swift
+++ b/Sources/Castor/Recipes/MutedRecipe.swift
@@ -26,7 +26,7 @@ final class MutedRecipe: NSObject, MutableReceiverStateRecipe {
     }
 
     func requestUpdate(to value: Bool, completion: @escaping (Bool) -> Void) -> Bool {
-        guard let session = service.currentCastSession, session.supportsMuting else { return false }
+        guard let session = service.currentCastSession else { return false }
         self.completion = completion
         let request = session.setDeviceMuted(value)
         request.delegate = self

--- a/Sources/Castor/Recipes/ShouldPlayRecipe.swift
+++ b/Sources/Castor/Recipes/ShouldPlayRecipe.swift
@@ -26,7 +26,7 @@ final class ShouldPlayRecipe: NSObject, MutableReceiverStateRecipe {
     }
 
     static func value(from status: GCKMediaStatus?) -> Bool {
-        [.playing, .buffering, .loading].contains(status?.playerState)
+        status?.shouldPlay == true
     }
 
     private static func request(for value: Bool, using remoteMediaClient: GCKRemoteMediaClient) -> GCKRequest {

--- a/Sources/Castor/Recipes/VolumeRecipe.swift
+++ b/Sources/Castor/Recipes/VolumeRecipe.swift
@@ -26,7 +26,7 @@ final class VolumeRecipe: NSObject, MutableReceiverStateRecipe {
     }
 
     func requestUpdate(to value: Float, completion: @escaping (Bool) -> Void) -> Bool {
-        guard let session = service.currentCastSession, !session.isFixedVolume else { return false }
+        guard let session = service.currentCastSession else { return false }
         self.completion = completion
         let request = session.setDeviceVolume(value)
         request.delegate = self

--- a/Sources/Castor/Types/CastLoadOptions.swift
+++ b/Sources/Castor/Types/CastLoadOptions.swift
@@ -9,13 +9,13 @@ import GoogleCast
 
 /// Options used when loading assets.
 public struct CastLoadOptions {
+    /// The index of the item at which playback should start.
+    public let startIndex: Int
+
     /// The time at which playback should start.
     ///
     /// `.invalid` for the default position.
     public let startTime: CMTime
-
-    /// The index of the item at which playback should start.
-    public let startIndex: Int
 
     /// A Boolean value that indicates whether the player should automatically play content when possible.
     public let shouldPlay: Bool
@@ -29,20 +29,20 @@ public struct CastLoadOptions {
     /// Creates loading options.
     /// 
     /// - Parameters:
-    ///   - startTime: The time at which playback should start. Use `.invalid` for the default position.
     ///   - startIndex: The index of the item at which playback should start.
+    ///   - startTime: The time at which playback should start. Use `.invalid` for the default position.
     ///   - shouldPlay: A Boolean value that indicates whether the player should automatically play content when possible.
     ///   - playbackSpeed: The playback speed to apply.
     ///   - repeatMode: The mode that determines how the player repeats playback of items in its queue.
     public init(
-        startTime: CMTime = .invalid,
         startIndex: Int = 0,
+        startTime: CMTime = .invalid,
         shouldPlay: Bool = true,
         playbackSpeed: Float = 1,
         repeatMode: CastRepeatMode = .off
     ) {
-        self.startTime = startTime
         self.startIndex = max(startIndex, 0)
+        self.startTime = startTime
         self.shouldPlay = shouldPlay
         self.playbackSpeed = playbackSpeed.clamped(to: 0.5...2)
         self.repeatMode = repeatMode

--- a/Sources/Castor/Types/CastLoadOptions.swift
+++ b/Sources/Castor/Types/CastLoadOptions.swift
@@ -9,17 +9,42 @@ import GoogleCast
 
 /// Options used when loading assets.
 public struct CastLoadOptions {
-    let rawOptions = GCKMediaQueueLoadOptions()
+    /// The time at which playback should start.
+    ///
+    /// `.invalid` for the default position.
+    public let startTime: CMTime
+
+    /// The index of the item at which playback should start.
+    public let startIndex: Int
+
+    /// A Boolean value that indicates whether the player should automatically play content when possible.
+    public let shouldPlay: Bool
+
+    /// The playback speed to apply.
+    public let playbackSpeed: Float
+
+    /// The mode that determines how the player repeats playback of items in its queue.
+    public let repeatMode: CastRepeatMode
 
     /// Creates loading options.
-    ///
+    /// 
     /// - Parameters:
-    ///   - startTime: The time at which playback should start.
+    ///   - startTime: The time at which playback should start. Use `.invalid` for the default position.
     ///   - startIndex: The index of the item at which playback should start.
-    public init(startTime: CMTime = .invalid, startIndex: Int = 0) {
-        if startTime.isValid {
-            rawOptions.playPosition = startTime.seconds
-        }
-        rawOptions.startIndex = UInt(max(startIndex, 0))
+    ///   - shouldPlay: A Boolean value that indicates whether the player should automatically play content when possible.
+    ///   - playbackSpeed: The playback speed to apply.
+    ///   - repeatMode: The mode that determines how the player repeats playback of items in its queue.
+    public init(
+        startTime: CMTime = .invalid,
+        startIndex: Int = 0,
+        shouldPlay: Bool = true,
+        playbackSpeed: Float = 1,
+        repeatMode: CastRepeatMode = .off
+    ) {
+        self.startTime = startTime
+        self.startIndex = max(startIndex, 0)
+        self.shouldPlay = shouldPlay
+        self.playbackSpeed = playbackSpeed.clamped(to: 0.5...2)
+        self.repeatMode = repeatMode
     }
 }

--- a/Sources/Castor/Types/CastLoadOptions.swift
+++ b/Sources/Castor/Types/CastLoadOptions.swift
@@ -27,7 +27,7 @@ public struct CastLoadOptions {
     public let repeatMode: CastRepeatMode
 
     /// Creates loading options.
-    /// 
+    ///
     /// - Parameters:
     ///   - startIndex: The index of the item at which playback should start.
     ///   - startTime: The time at which playback should start. Use `.invalid` for the default position.

--- a/Sources/Castor/Types/CastRepeatMode.swift
+++ b/Sources/Castor/Types/CastRepeatMode.swift
@@ -7,7 +7,7 @@
 import GoogleCast
 
 /// A mode that determines how the player repeats playback of items in its queue.
-public enum CastRepeatMode {
+public enum CastRepeatMode: CaseIterable {
     /// Disabled.
     case off
 

--- a/Sources/Castor/Types/CastResumeState.swift
+++ b/Sources/Castor/Types/CastResumeState.swift
@@ -21,8 +21,7 @@ public struct CastResumeState {
     ///
     /// - Parameters:
     ///   - assets: The assets in the queue.
-    ///   - index: The current index in the asset list.
-    ///   - time: The current playback time. Use `.invalid` for the default position.
+    ///   - options: The options to use when resuming playback.
     ///
     /// Fails if the provided index is not valid for the asset list.
     public init?(assets: [CastAsset], options: CastLoadOptions) {

--- a/Sources/Castor/Types/CastResumeState.swift
+++ b/Sources/Castor/Types/CastResumeState.swift
@@ -12,13 +12,8 @@ public struct CastResumeState {
     /// The assets in the queue.
     public let assets: [CastAsset]
 
-    /// The current index in the asset list.
-    public let index: Int
-
-    /// The current playback time.
-    ///
-    /// A value of `.invalid` corresponds to the default playback position.
-    public let time: CMTime
+    /// The options to use when resuming playback.
+    public let options: CastLoadOptions
 
     private var mediaSelectionLanguages: [AVMediaCharacteristic: String] = [:]
 
@@ -30,11 +25,10 @@ public struct CastResumeState {
     ///   - time: The current playback time. Use `.invalid` for the default position.
     ///
     /// Fails if the provided index is not valid for the asset list.
-    public init?(assets: [CastAsset], index: Int?, time: CMTime) {
-        guard let index, assets.indices.contains(index) else { return nil }
+    public init?(assets: [CastAsset], options: CastLoadOptions) {
+        guard assets.indices.contains(options.startIndex) else { return nil }
         self.assets = assets
-        self.index = index
-        self.time = time
+        self.options = options
     }
 }
 

--- a/Tests/CastorTests/CastResumeStateTests.swift
+++ b/Tests/CastorTests/CastResumeStateTests.swift
@@ -13,7 +13,7 @@ import Testing
 struct CastResumeStateTests {
     @Test
     func empty() throws {
-        #expect(CastResumeState(assets: [], index: nil, time: .invalid) == nil)
+        #expect(CastResumeState(assets: [], options: .init(startIndex: 0, startTime: .invalid)) == nil)
     }
 
     @Test
@@ -23,14 +23,10 @@ struct CastResumeStateTests {
                 assets: [
                     .url(URL(string: "https://localhost/stream.m3u8")!, metadata: nil)
                 ],
-                index: 0,
-                time: .zero
+                options: .init(startIndex: 0, startTime: .zero)
             )
         )
         #expect(state.assets.count == 1)
-        #expect(state.index == 0)
-        #expect(state.time == .zero)
-        #expect(state.mediaSelectionLanguage(for: .legible) == nil)
     }
 
     @Test
@@ -40,8 +36,7 @@ struct CastResumeStateTests {
                 assets: [
                     .url(URL(string: "https://localhost/stream.m3u8")!, metadata: nil)
                 ],
-                index: 1,
-                time: .zero
+                options: .init(startIndex: 1, startTime: .zero)
             ) == nil
         )
     }
@@ -53,8 +48,7 @@ struct CastResumeStateTests {
                 assets: [
                     .url(URL(string: "https://localhost/stream.m3u8")!, metadata: nil)
                 ],
-                index: 0,
-                time: .zero
+                options: .init(startIndex: 0, startTime: .zero)
             )
         )
         state.setMediaSelection(language: "fr", for: .legible)


### PR DESCRIPTION
## Description

This PR ensures the following playback parameters can be transferred between sender and receiver:

- Whether the player should start playing or paused.
- Repeat mode.
- Playback speed.

## Changes made

- Use `CastLoadOptions` to define parameters before playback starts. Mutable property wrappers ensure synchronization during playback but attempting to use these properties to support initial values is tricky, especially since there is a native Google Cast SDK API to support defining values at loading time. Note that the only exception is media selection, for which we need to wait until playback starts to determine the available track IDs.
- Transfer these parameters between sender and receiver.
- Make `CastRepeatMode` case iterable for more ergonomic use with UI components.
- Add repeat mode setting to the local/remote demo settings menus.
- Move muted/volume value sanitization from their corresponding recipes (dumb, only define communication) to the caller (the player).
- Fix menu display on iOS 16 (options could not be selected). The subtitle is not displayed on this iOS version, though.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
