### PR TITLE
Animate mini player view when appearing or disappearing

### DIFF
--- a/Demo/Sources/Application/RootView.swift
+++ b/Demo/Sources/Application/RootView.swift
@@ -26,6 +26,7 @@ private struct MiniPlayer: View {
                     .onTapGesture(perform: showPlayer)
                     .accessibilityAddTraits(.isButton)
                     .frame(height: 64)
+                    .geometryGroup17()
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }

--- a/Demo/Sources/Application/RootView.swift
+++ b/Demo/Sources/Application/RootView.swift
@@ -26,7 +26,6 @@ private struct MiniPlayer: View {
                     .onTapGesture(perform: showPlayer)
                     .accessibilityAddTraits(.isButton)
                     .frame(height: 64)
-                    .geometryGroup17()
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }

--- a/Demo/Sources/Application/RootView.swift
+++ b/Demo/Sources/Application/RootView.swift
@@ -7,12 +7,48 @@
 import Castor
 import SwiftUI
 
-struct RootView: View {
-    @StateObject private var cast = Cast(configuration: .standard)
-    @StateObject private var router = Router()
+private struct MiniPlayer: View {
+    @ObservedObject var player: CastPlayer
+
+    @EnvironmentObject private var cast: Cast
+    @EnvironmentObject private var router: Router
 
     @AppStorage(UserDefaults.DemoSettingKey.playerType)
     private var playerType: PlayerType = .standard
+
+    var body: some View {
+        ZStack {
+            if isLoaded {
+                CastMiniPlayerView(cast: cast)
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+                    .background(.thickMaterial)
+                    .onTapGesture(perform: showPlayer)
+                    .accessibilityAddTraits(.isButton)
+                    .frame(height: 64)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.default, value: isLoaded)
+    }
+
+    private var isLoaded: Bool {
+        !player.items.isEmpty
+    }
+
+    private func showPlayer() {
+        switch playerType {
+        case .standard:
+            router.presented = .remotePlayer
+        case .unified:
+            router.presented = .unifiedPlayer
+        }
+    }
+}
+
+struct RootView: View {
+    @StateObject private var cast = Cast(configuration: .standard)
+    @StateObject private var router = Router()
 
     var body: some View {
         TabView {
@@ -52,23 +88,8 @@ struct RootView: View {
 
     @ViewBuilder
     private func miniPlayer() -> some View {
-        if cast.player != nil {
-            CastMiniPlayerView(cast: cast)
-                .padding(.horizontal)
-                .padding(.vertical, 8)
-                .onTapGesture(perform: showPlayer)
-                .accessibilityAddTraits(.isButton)
-                .background(.thickMaterial)
-                .frame(height: 64)
-        }
-    }
-
-    private func showPlayer() {
-        switch playerType {
-        case .standard:
-            router.presented = .remotePlayer
-        case .unified:
-            router.presented = .unifiedPlayer
+        if let player = cast.player {
+            MiniPlayer(player: player)
         }
     }
 }

--- a/Demo/Sources/Extensions/View.swift
+++ b/Demo/Sources/Extensions/View.swift
@@ -18,6 +18,18 @@ private struct PulseSymbolEffect17: ViewModifier {
     }
 }
 
+private struct GeometryGroup17: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .geometryGroup()
+        }
+        else {
+            content
+        }
+    }
+}
+
 extension View {
     /// Prevents touch propagation to views located below the receiver.
     func preventsTouchPropagation() -> some View {
@@ -26,5 +38,9 @@ extension View {
 
     func pulseSymbolEffect17() -> some View {
         modifier(PulseSymbolEffect17())
+    }
+
+    func geometryGroup17() -> some View {
+        modifier(GeometryGroup17())
     }
 }

--- a/Demo/Sources/Extensions/View.swift
+++ b/Demo/Sources/Extensions/View.swift
@@ -18,18 +18,6 @@ private struct PulseSymbolEffect17: ViewModifier {
     }
 }
 
-private struct GeometryGroup17: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 17.0, *) {
-            content
-                .geometryGroup()
-        }
-        else {
-            content
-        }
-    }
-}
-
 extension View {
     /// Prevents touch propagation to views located below the receiver.
     func preventsTouchPropagation() -> some View {
@@ -38,9 +26,5 @@ extension View {
 
     func pulseSymbolEffect17() -> some View {
         modifier(PulseSymbolEffect17())
-    }
-
-    func geometryGroup17() -> some View {
-        modifier(GeometryGroup17())
     }
 }

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -34,7 +34,7 @@ struct Media: Hashable, Identifiable {
     }
 
     init(from asset: CastAsset) {
-        let title = asset.metadata?.title ?? "Untitled"
+        let title = asset.metadata?.title ?? "Unknown"
         let imageUrl = asset.metadata?.imageUrl()
         switch asset.kind {
         case let .entity(urn), let .identifier(urn):

--- a/Demo/Sources/Player/RemotePlaybackView.swift
+++ b/Demo/Sources/Player/RemotePlaybackView.swift
@@ -22,7 +22,7 @@ private struct RemoteItemCell: View {
 
     private var title: String {
         guard item.isFetched else { return "..." }
-        return item.asset?.metadata?.title ?? "Untitled"
+        return item.asset?.metadata?.title ?? "Unknown"
     }
 
     private func disclosureImage() -> some View {

--- a/Package.resolved
+++ b/Package.resolved
@@ -70,7 +70,7 @@
       "location" : "https://github.com/SRGSSR/pillarbox-apple",
       "state" : {
         "branch" : "main",
-        "revision" : "9c9a4e48de0c418662bb2b6be01ddcd61f540be0"
+        "revision" : "4c26d9d9919b0e9213e8b6f5f99d020ebe0e05d7"
       }
     },
     {

--- a/Sources/Castor/Cast/CastDevice.swift
+++ b/Sources/Castor/Cast/CastDevice.swift
@@ -55,7 +55,7 @@ extension CastDevice {
     }
 
     static func route(to device: CastDevice?) -> String {
-        String(localized: "Casting on \(name(for: device))", bundle: .module, comment: "Current Cast receiver (with device name as wildcard)")
+        String(localized: "Connected to \(name(for: device))", bundle: .module, comment: "Connected receiver (device name as wildcard)")
     }
 }
 

--- a/Sources/Castor/Extensions/View.swift
+++ b/Sources/Castor/Extensions/View.swift
@@ -6,6 +6,18 @@
 
 import SwiftUI
 
+private struct GeometryGroup17: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .geometryGroup()
+        }
+        else {
+            content
+        }
+    }
+}
+
 public extension View {
     /// Binds a progress tracker to a player.
     ///
@@ -53,5 +65,9 @@ extension View {
 
     func redacted(_ condition: Bool) -> some View {
         redacted(reason: condition ? .placeholder : .init())
+    }
+
+    func geometryGroup17() -> some View {
+        modifier(GeometryGroup17())
     }
 }

--- a/Sources/Castor/Player/CastAsset.swift
+++ b/Sources/Castor/Player/CastAsset.swift
@@ -192,9 +192,9 @@ public extension CastAsset {
 }
 
 extension CastAsset {
-    static func name(for asset: CastAsset?) -> String {
+    static func description(for asset: CastAsset?) -> String {
         guard let asset else {
-            return String(localized: "Idle", bundle: .module, comment: "Generic label displayed when the Cast receiver is idle")
+            return String(localized: "Not playing", bundle: .module, comment: "Label displayed when no content is being played")
         }
         return asset.metadata?.title ?? String(localized: "Unknown", bundle: .module, comment: "Generic name for a Cast asset")
     }

--- a/Sources/Castor/Player/CastAsset.swift
+++ b/Sources/Castor/Player/CastAsset.swift
@@ -193,6 +193,6 @@ public extension CastAsset {
 
 extension CastAsset {
     static func name(for asset: CastAsset?) -> String {
-        asset?.metadata?.title ?? String(localized: "Unknown", bundle: .module, comment: "Generic name for a Cast device")
+        asset?.metadata?.title ?? String(localized: "Unknown", bundle: .module, comment: "Generic name for a Cast asset")
     }
 }

--- a/Sources/Castor/Player/CastAsset.swift
+++ b/Sources/Castor/Player/CastAsset.swift
@@ -194,7 +194,7 @@ public extension CastAsset {
 extension CastAsset {
     static func name(for asset: CastAsset?) -> String {
         guard let asset else {
-            return String(localized: "Idle", bundle: .module, comment: "Generic name displayed when no asset is loaded")
+            return String(localized: "Idle", bundle: .module, comment: "Generic label displayed when the Cast receiver is idle")
         }
         return asset.metadata?.title ?? String(localized: "Unknown", bundle: .module, comment: "Generic name for a Cast asset")
     }

--- a/Sources/Castor/Player/CastAsset.swift
+++ b/Sources/Castor/Player/CastAsset.swift
@@ -193,6 +193,9 @@ public extension CastAsset {
 
 extension CastAsset {
     static func name(for asset: CastAsset?) -> String {
-        asset?.metadata?.title ?? String(localized: "Unknown", bundle: .module, comment: "Generic name for a Cast asset")
+        guard let asset else {
+            return String(localized: "Idle", bundle: .module, comment: "Generic name displayed when no asset is loaded")
+        }
+        return asset.metadata?.title ?? String(localized: "Unknown", bundle: .module, comment: "Generic name for a Cast asset")
     }
 }

--- a/Sources/Castor/Resources/Localizable.xcstrings
+++ b/Sources/Castor/Resources/Localizable.xcstrings
@@ -640,7 +640,7 @@
       }
     },
     "Idle" : {
-      "comment" : "Generic name displayed when no asset is loaded"
+      "comment" : "Generic label displayed when the Cast receiver is idle"
     },
     "Live" : {
       "comment" : "Short label associated with live content",

--- a/Sources/Castor/Resources/Localizable.xcstrings
+++ b/Sources/Castor/Resources/Localizable.xcstrings
@@ -639,6 +639,9 @@
         }
       }
     },
+    "Idle" : {
+      "comment" : "Generic name displayed when no asset is loaded"
+    },
     "Live" : {
       "comment" : "Short label associated with live content",
       "localizations" : {
@@ -1249,7 +1252,7 @@
       }
     },
     "Unknown" : {
-      "comment" : "Generic name for a Cast device",
+      "comment" : "Generic name for a Cast asset\nGeneric name for a Cast device",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Sources/Castor/Resources/Localizable.xcstrings
+++ b/Sources/Castor/Resources/Localizable.xcstrings
@@ -204,35 +204,6 @@
         }
       }
     },
-    "Casting on %@" : {
-      "comment" : "Current Cast receiver (with device name as wildcard)",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Übertragung auf %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diffusion sur %@"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trasmissione su %@"
-          }
-        },
-        "rm" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transmetter sin %@"
-          }
-        }
-      }
-    },
     "Check your Wi-Fi network and make sure Local Network Access is on." : {
       "comment" : "Action suggested when no Cast receivers are found",
       "localizations" : {
@@ -639,9 +610,6 @@
         }
       }
     },
-    "Idle" : {
-      "comment" : "Generic label displayed when the Cast receiver is idle"
-    },
     "Live" : {
       "comment" : "Short label associated with live content",
       "localizations" : {
@@ -828,7 +796,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A l'arrêt"
+            "value" : "À l'arrêt"
           }
         },
         "it" : {

--- a/Sources/Castor/UserInterface/CastMiniPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastMiniPlayerView.swift
@@ -72,7 +72,7 @@ private extension _CastMiniPlayerView {
     }
 
     private func title(for asset: CastAsset?) -> some View {
-        Text(CastAsset.name(for: asset))
+        Text(CastAsset.description(for: asset))
             .font(.subheadline)
             .bold()
             .lineLimit(1)
@@ -88,6 +88,6 @@ private extension _CastMiniPlayerView {
 
 private extension _CastMiniPlayerView {
     var accessibilityLabel: String {
-        "\(CastAsset.name(for: player.currentAsset)), \(CastDevice.route(to: cast.currentDevice))"
+        "\(CastAsset.description(for: player.currentAsset)), \(CastDevice.route(to: cast.currentDevice))"
     }
 }

--- a/Sources/Castor/UserInterface/CastMiniPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastMiniPlayerView.swift
@@ -18,6 +18,7 @@ private struct _CastMiniPlayerView: View {
             playbackButton()
         }
         .contentShape(.rect)
+        .geometryGroup17()
     }
 
     private func artwork(for asset: CastAsset?) -> some View {

--- a/Sources/Castor/UserInterface/CastMiniPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastMiniPlayerView.swift
@@ -11,15 +11,13 @@ private struct _CastMiniPlayerView: View {
     @ObservedObject var cast: Cast
 
     var body: some View {
-        if ![.idle, .unknown].contains(player.state) {
-            HStack(spacing: 20) {
-                artwork(for: player.currentAsset)
-                infoView(for: player.currentAsset)
-                Spacer()
-                playbackButton()
-            }
-            .contentShape(.rect)
+        HStack(spacing: 20) {
+            artwork(for: player.currentAsset)
+            infoView(for: player.currentAsset)
+            Spacer()
+            playbackButton()
         }
+        .contentShape(.rect)
     }
 
     private func artwork(for asset: CastAsset?) -> some View {
@@ -38,6 +36,7 @@ private struct _CastMiniPlayerView: View {
     private func playbackButton() -> some View {
         PlaybackButton(player: player)
             .font(.system(size: 40))
+            .disabled(!player.isActive)
     }
 }
 

--- a/Sources/Castor/UserInterface/CastMiniPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastMiniPlayerView.swift
@@ -40,7 +40,7 @@ private struct _CastMiniPlayerView: View {
     }
 }
 
-/// A mini cast player view.
+/// A mini Cast player view.
 public struct CastMiniPlayerView: View {
     @ObservedObject private var cast: Cast
 

--- a/Sources/Castor/UserInterface/CastPlayerView.swift
+++ b/Sources/Castor/UserInterface/CastPlayerView.swift
@@ -121,7 +121,7 @@ private struct _CastPlayerView: View {
                     .foregroundStyle(.secondary)
             }
             else {
-                Text(CastAsset.name(for: player.currentAsset))
+                Text(CastAsset.description(for: player.currentAsset))
             }
         }
         .bold()

--- a/Sources/Castor/UserInterface/Player/ItemCell.swift
+++ b/Sources/Castor/UserInterface/Player/ItemCell.swift
@@ -24,7 +24,7 @@ struct ItemCell: View {
 
     private var title: String {
         guard item.isFetched else { return .placeholder(length: .random(in: 20...30)) }
-        return CastAsset.name(for: item.asset)
+        return CastAsset.description(for: item.asset)
     }
 
     private func artworkImage() -> some View {


### PR DESCRIPTION
## Description

This PR improves our `CastMiniPlayerView` implementation so that applications can:

- Choose in which circumstances the mini player is displayed (including when no content has been loaded).
- Choose if mini player view transitions must be animated and how.

## Changes made

- Remove any player-based display criteria from `CastMiniPlayerView` implementation and ensure it displays a consistent state in all cases, even when no content has been loaded.
- Avoid animations propagating to the mini player view in an unexpected way (internal geometry group).
- Animate mini player view in our demo (slide and fade).
- Improve name placeholder consistency.
- Update translations.
- Update Pillarbox.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
