### PR TITLE
Avoid item loading issues on Android TV receivers

### DIFF
--- a/Sources/Castor/Player/CastPlayer+Items.swift
+++ b/Sources/Castor/Player/CastPlayer+Items.swift
@@ -29,13 +29,12 @@ public extension CastPlayer {
     ///   - options: The options to use when loading.
     func loadItems(from assets: [CastAsset], with options: CastLoadOptions = .init()) {
         let queueDataBuilder = GCKMediaQueueDataBuilder(queueType: .generic)
-        let items = Self.rawItems(from: assets)
-        queueDataBuilder.items = items
+        queueDataBuilder.items = Self.rawItems(from: assets)
         queueDataBuilder.startIndex = UInt(options.index)
         queueDataBuilder.repeatMode = options.repeatMode.rawMode()
 
         let loadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
-        loadRequestDataBuilder.mediaInformation = items[safeIndex: options.index]?.mediaInformation
+        loadRequestDataBuilder.mediaInformation = .init()
         loadRequestDataBuilder.queueData = queueDataBuilder.build()
         loadRequestDataBuilder.autoplay = .init(value: options.shouldPlay)
         loadRequestDataBuilder.playbackRate = options.playbackSpeed


### PR DESCRIPTION
## Description

We have recently [updated our implementation](https://github.com/SRGSSR/castor/blob/1.0.0/Sources/Castor/Player/CastPlayer%2BItems.swift#L30-L44) to transfer playback settings from sender to receiver.

Sadly the Android TV receiver `onLoad` hook is not called with our current implementation, which means [items do not load](https://github.com/SRGSSR/pillarbox-android/issues/1182). The same is true if the same API is used when loading content from an Android sender.

### Remark

The standard Google Cast receivers as well as our SRG SSR receiver retrieve the start time from the media load request data (`GCKMediaLoadRequestData` sender-side). There is another start time which can be provided in the media queue data  (`GCKMediaQueueData` sender-side), but which is ignored by these receivers.

Our Android TV receiver, though, currently retrieves the start time from the media queue data. We should align it with other receivers so that it retrieves this start time from the media load request data instead. Castor and Pillarbox Android implementations both work with the start time retrieved from this field, whether _load media_ APIs or _load request data APIs are used (on iOS Google Cast internals inspection reveals that _load media_ APIs ultimately end up calling _load request data_ APIs anyway).

## Changes made

The media load request API requires [special care](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_media_load_request_data), but it seems that adding a dummy empty media info suffices to fix the issues we observed (first commit proposal). This is also a fix that has been made by our web sender implementation with success.

A second option is to send the media information associated with the item at the specified start index (second commit proposal). This is less hacky but, comparing the result on all our receivers (standard receiver, SRG SSR web receiver, as well as a pre-version of the fixed Android TV receiver) there is no perceived difference between both options.

In the end the 1st simpler implementation seems to suffice. This is the change proposed by this PR (the history remains available should we discover an issue later).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo _(see remark above for our Android TV receiver)_.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
