### PR TITLE
Use modern localization references

### DIFF
--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -57,7 +57,7 @@ struct ExamplesView: View {
         }
     }
 
-    private func section(_ titleKey: LocalizedStringKey, medias: [Media]) -> some View {
+    private func section(_ titleKey: LocalizedStringResource, medias: [Media]) -> some View {
         Section(titleKey) {
             ForEach(medias) { media in
                 button(for: media)

--- a/Demo/Sources/Extensions/CastRepeatMode.swift
+++ b/Demo/Sources/Extensions/CastRepeatMode.swift
@@ -9,7 +9,7 @@ import PillarboxPlayer
 import SwiftUI
 
 extension CastRepeatMode {
-    var name: LocalizedStringKey {
+    var name: LocalizedStringResource {
         switch self {
         case .off:
             "Off"

--- a/Demo/Sources/Extensions/RepeatMode.swift
+++ b/Demo/Sources/Extensions/RepeatMode.swift
@@ -9,7 +9,7 @@ import PillarboxPlayer
 import SwiftUI
 
 extension RepeatMode {
-    var name: LocalizedStringKey {
+    var name: LocalizedStringResource {
         switch self {
         case .off:
             "Off"

--- a/Demo/Sources/Model/Receiver.swift
+++ b/Demo/Sources/Model/Receiver.swift
@@ -30,7 +30,7 @@ enum Receiver: Int, CaseIterable {
         }
     }
 
-    var name: LocalizedStringKey {
+    var name: LocalizedStringResource {
         switch self {
         case .standard:
             "Standard"

--- a/Demo/Sources/Player/PlayerType.swift
+++ b/Demo/Sources/Player/PlayerType.swift
@@ -11,7 +11,7 @@ enum PlayerType: Int, CaseIterable {
     case standard
     case unified
 
-    var name: LocalizedStringKey {
+    var name: LocalizedStringResource {
         switch self {
         case .standard:
             "Standard"

--- a/Demo/Sources/Player/PlaylistSelectionView.swift
+++ b/Demo/Sources/Player/PlaylistSelectionView.swift
@@ -61,7 +61,7 @@ struct PlaylistSelectionView: View {
         }
     }
 
-    private func section(_ titleKey: LocalizedStringKey, medias: [Media]) -> some View {
+    private func section(_ titleKey: LocalizedStringResource, medias: [Media]) -> some View {
         Section(titleKey) {
             ForEach(medias) { media in
                 Text(media.title)
@@ -96,7 +96,7 @@ extension PlaylistSelectionView {
         case insertAfter
         case append
 
-        var name: LocalizedStringKey {
+        var name: LocalizedStringResource {
             switch self {
             case .prepend:
                 "Prepend"

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -104,7 +104,7 @@ struct SettingsView: View {
         }
     }
 
-    private func skipPicker(_ titleKey: LocalizedStringKey, selection: Binding<TimeInterval>) -> some View {
+    private func skipPicker(_ titleKey: LocalizedStringResource, selection: Binding<TimeInterval>) -> some View {
         Picker(titleKey, selection: selection) {
             ForEach([TimeInterval]([5, 7, 10, 15, 30, 45, 60, 75, 90]), id: \.self) { interval in
                 Text("\(Int(interval)) seconds")


### PR DESCRIPTION
## Description

This PR replaces `LocalizedStringKey` with its modern `LocalizedStringResource` iOS 16 counterpart, which offers better support for tables and bundles.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
