### PR TITLE
Fix queue synchronization with Android TV receiver

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,15 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", .upToNextMinor(from: "4.8.3"))
+        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", .upToNextMinor(from: "4.8.3")),
+        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(
             name: "Castor",
             dependencies: [
-                .product(name: "GoogleCast", package: "google-cast-sdk")
+                .product(name: "GoogleCast", package: "google-cast-sdk"),
+                .product(name: "OrderedCollections", package: "swift-collections")
             ],
             resources: [
                 .process("Resources")


### PR DESCRIPTION
## Description

This PR fixes synchronization with the Android TV receiver when removing the current item if it is the last one.

> [!NOTE]
> This PR is not intended to be merged quickly, as it affects only the Android TV receiver and addresses a single use case.

## Implementation Considerations

### Context

- Initial queue

```
    Selected
       |
       v
[A, B, C]
```

- The user deletes the last item (`C`).

### Current Behavior

The iOS sender removes the last item and always sends a queue reordering request.

- On the Web receiver, this does not cause any issue (the reorder request seems to be ignored).
- On the Android TV receiver, the reorder request is not ignored.

Result:

- Playback stops on the receiver.
- The sender receives the reorder response and displays a playlist that is no longer synchronized with the Android TV receiver.

### iOS Sender: Current code

```swift
let removeRequest = service.queueRemoveItems(withIDs: removedIds)
removeRequest.delegate = self

let reorderRequest = service.queueReorderItems(withIDs: currentIds, insertBeforeItemWithID: kGCKMediaQueueInvalidItemID)
reorderRequest.delegate = self
```

### Sender / Receiver interactions

#### Sender

1. `queueRemoveItems([C])`
2. `queueReorderItems([A, B])`

#### Receiver

1. Remove
   - Item `C` is removed.
   - Playback stops because the last item has been removed.
2. Reorder
   - The queue now contains `[A, B]`.
   - The sender is notified and updates its UI to `[A, B]` while playback is already stopped on the receiver.

#### Issue

The iOS sender and the Android TV receiver are not sync anymore:

- The sender shows a non empty playlist.
- The receiver has stopped playback after removing the last item.

| Issue |
|--------|
| <video src="https://github.com/user-attachments/assets/b2f9f762-c805-4f0b-9291-372a85f4f5b0" /> | 

## First fix (Request order inversion)

### Updated Code

```swift
let reorderRequest = service.queueReorderItems(withIDs: currentIds, insertBeforeItemWithID: kGCKMediaQueueInvalidItemID)
reorderRequest.delegate = self

let removeRequest = service.queueRemoveItems(withIDs: removedIds)
removeRequest.delegate = self
```

#### Sender

1. `queueReorderItems([A, B])`
2. `queueRemoveItems([C])`

#### Receiver

1. Reorder
   - Item `C` is already removed from the queue.
   - The receiver recomputes the current item.
   - Playback continues on item `A`.
2. Remove
   - Item `C` is removed.
   - No effect since `C` is no longer the last item.

#### Advantage

Removing the last item no longer stops playback.

#### Issue

Sender behaviors diverge across platforms.

## Second fix (Conditional requests)

Instead of always sending both requests, the sender sends only the desired requests.
(See the code attached to this PR.)

### Sender

#### Deletion case

1. `queueRemoveItems([C])`
2. No reorder request.

##### Receiver

1. Remove
   - The last item `C` is removed.
   - Playback stops.
   - No additional reorder request is received.

#### Result

- Sender and receiver remain synchronized.
- Playback behavior is consistent across platforms.
- The iOS sender behaves consistently with other senders (Web, Android).

| Fix |
|--------|
| <video src="https://github.com/user-attachments/assets/4cdb7b9f-db5b-4f3c-b969-76ebab399e55"/> | 

## Conclusion

The adopted strategy is the second one, this approach:

- Prevents unintended side effects caused by unconditional reordering.
- Keeps sender and receiver states synchronized.
- Aligns the iOS sender behavior with other platforms.

> [!WARNING]
> While multiple scenarios have been tested, some edge cases may still have been missed, and additional testing is strongly recommended.

## Changes made

- `queueRemoveItems` and `queueReorderItems` have been conditioned.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
