### PR TITLE
Replace ImageMagick by GraphicsMagick

### DIFF
--- a/Scripts/private/deliver-demo.sh
+++ b/Scripts/private/deliver-demo.sh
@@ -12,7 +12,7 @@ function usage {
 function install_tools {
     curl -Ssf https://pkgx.sh | sh &> /dev/null
     set -a
-    eval "$(pkgx +ruby@3.3.0 +bundle +rsvg-convert +magick)"
+    eval "$(pkgx +ruby@3.3.0 +bundle +rsvg-convert +gm)"
     set +a
 }
 


### PR DESCRIPTION
## Description

This PR replaces `ImageMagick` by `GraphicsMagick` to avoid nightly delivery issue. This issue seems to be introduced by a [pkgx pantry PR](https://github.com/pkgxdev/pantry/pull/11726).

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
