### PR TITLE
Fix pkgx "no intersection possible" issue

### DIFF
--- a/Scripts/private/deliver-demo.sh
+++ b/Scripts/private/deliver-demo.sh
@@ -12,7 +12,7 @@ function usage {
 function install_tools {
     curl -Ssf https://pkgx.sh | sh &> /dev/null
     set -a
-    eval "$(pkgx +ruby@3.3.0 +bundle +rsvg-convert +magick)"
+    eval "$(pkgx +ruby@3.3.0 +bundle +rsvg-convert)"
     set +a
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue which were probably latent and revealed by [recent pkgx changes](https://github.com/pkgxdev/pantry/issues/11724). We should be able to only use `rsvg-convert` and have Imagemagick pulled automatically without conflict.

## Changes made

- Revert #249.
- Remove `magick` from tool list.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
