### PR TITLE
Use commit hash for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: make test
 
       - name: Publish report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@v6  # v6
         if: always()
         with:
           report_paths: 'fastlane/test_output/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
         run: make test
 
       - name: Publish report
-        uses: mikepenz/action-junit-report@v6  # v6
+        uses: |
+          mikepenz/action-junit-report\
+          @bccf2e31636835cf0874589931c4116687171386 #  v6.4.0
         if: always()
         with:
           report_paths: 'fastlane/test_output/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: |
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #  v6.0.2
 
       - name: Run the quality check
         run: make check-quality
@@ -23,16 +22,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: |
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #  v6.0.2
 
       - name: Run test
         run: make test
 
       - name: Publish report
-        uses: |
-          mikepenz/action-junit-report\
-          @bccf2e31636835cf0874589931c4116687171386 #  v6.4.0
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386  #  v6.4.0
         if: always()
         with:
           report_paths: 'fastlane/test_output/*.xml'
@@ -44,8 +40,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: |
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #  v6.0.2
 
       - name: Skip plugin validation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: |
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
 
       - name: Run the quality check
         run: make check-quality
@@ -22,7 +23,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: |
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
 
       - name: Run test
         run: make test
@@ -40,7 +42,8 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: |
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
 
       - name: Skip plugin validation
         run: |

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -12,7 +12,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: |
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -12,8 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: |
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #  v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: |
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,8 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: |
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #  v6.0.2
         with:
           fetch-depth: 0
 

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,4 @@
+---
 default: true
 
 MD013: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 100
+    level: warning


### PR DESCRIPTION
## Description

This PR aims to use the hash commit for actions providing immutability, unlike tags which do not. (See also: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)

## Changes made

- A hash commit has been used for [mikepenz/action-junit-report](https://github.com/mikepenz/action-junit-report).
- A hash commit has been used for [actions/checkout](https://github.com/actions/checkout).
- A `.yamllint` file has been introduced.
- The markdown lint file extension has been switched from `.yaml` to `.yml`.
- The Actions repository configuration has been updated to force SHA-pinning.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
