### PR TITLE
Install pkgx via Homebrew

### DIFF
--- a/Scripts/private/deliver-demo.sh
+++ b/Scripts/private/deliver-demo.sh
@@ -10,7 +10,7 @@ function usage {
 }
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a
     eval "$(pkgx +ruby@3.3.0 +bundle +magick)"
     set +a

--- a/Scripts/public/build-demo.sh
+++ b/Scripts/public/build-demo.sh
@@ -3,7 +3,7 @@
 set -e
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a
     eval "$(pkgx +ruby@3.3.0 +bundle)"
     set +a

--- a/Scripts/public/check-quality.sh
+++ b/Scripts/public/check-quality.sh
@@ -11,7 +11,7 @@ function usage {
 }
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a
     eval "$(pkgx +swiftlint +shellcheck +markdownlint)"
     set +a

--- a/Scripts/public/clean-imports.sh
+++ b/Scripts/public/clean-imports.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a
     eval "$(pkgx +swiftlint)"
     set +a

--- a/Scripts/public/find-dead-code.sh
+++ b/Scripts/public/find-dead-code.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a
     eval "$(pkgx +periphery)"
     set +a

--- a/Scripts/public/fix-quality.sh
+++ b/Scripts/public/fix-quality.sh
@@ -3,7 +3,7 @@
 set -e
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a
     eval "$(pkgx +swiftlint)"
     set +a

--- a/Scripts/public/test.sh
+++ b/Scripts/public/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 function install_tools {
-    curl -Ssf https://pkgx.sh | sh &> /dev/null
+    brew install pkgx &> /dev/null
     set -a;
     eval "$(pkgx +ruby@3.3.0 +bundle +xcodes)"
     set +a


### PR DESCRIPTION
## Description

This PR installs pkgx via Homebrew. Homebrew is quite standard, readily installed on GitHub Actions runner, and avoids having to enter one's password for installation.

## Changes made

- Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
