### PR TITLE
Annotate protocols with `@MainActor`

### DIFF
--- a/Demo/Sources/Application/Router.swift
+++ b/Demo/Sources/Application/Router.swift
@@ -32,7 +32,6 @@ extension Router {
             }
         }
 
-        @MainActor
         @ViewBuilder
         func view() -> some View {
             switch self {

--- a/Sources/Castor/Cast/CastDelegate.swift
+++ b/Sources/Castor/Cast/CastDelegate.swift
@@ -5,6 +5,7 @@
 //
 
 /// A protocol for handling events related to a cast session.
+@MainActor
 public protocol CastDelegate: AnyObject {
     /// Invoked when a Cast session has been established.
     func castStartSession()

--- a/Sources/Castor/Cast/Castable.swift
+++ b/Sources/Castor/Cast/Castable.swift
@@ -5,6 +5,7 @@
 //
 
 /// A protocol that defines a castable context.
+@MainActor
 public protocol Castable: AnyObject {
     /// Invoked when a Cast session has been established.
     ///


### PR DESCRIPTION
## Description

Methods from `GCKSessionManagerListener` are called on the main actor. This is not guaranteed through the API, rather known for a fact, since Google Cast SDK predates concurrency. Our implementation silently checks this behavior since `Cast` `@preconcurrency`-conforms to `GCKSessionManagerListener`, ensuring incorrectly assumed main actor isolation would raise an exception at runtime.

Still our protocols `Castable` and `CastDelegate` protocols, whose methods end up being called on the main thread in response to `GCKSessionManagerListener` delegate method calls, were not themselves annotated with `@MainActor`. This created friction when implementing these protocols in an app, usually on main actor isolated types:

- Either app developers would throw a `@preconcurrency` conformance just to get rid of the warnings.
- Or they would introduce `@MainActor`-conformance, which was based on some secret knowledge of Castor internals.

Instead of requiring arcane knowledge of Castor internals or dirty tricks, our two protocols now formally declare their methods to be called on the main actor.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
