### PR TITLE
Loosen main actor requirements

### DIFF
--- a/Sources/Castor/Cast/CastDelegate.swift
+++ b/Sources/Castor/Cast/CastDelegate.swift
@@ -5,13 +5,14 @@
 //
 
 /// A protocol for handling events related to a cast session.
-@MainActor
 public protocol CastDelegate: AnyObject {
     /// Invoked when a Cast session has been established.
+    @MainActor
     func castStartSession()
 
     /// Invoked when the Cast session is about to stop.
     ///
     /// - Parameter state: The state immediately before the Cast session ends.
+    @MainActor
     func castEndSession(with state: CastResumeState?)
 }

--- a/Sources/Castor/Cast/Castable.swift
+++ b/Sources/Castor/Cast/Castable.swift
@@ -5,15 +5,16 @@
 //
 
 /// A protocol that defines a castable context.
-@MainActor
 public protocol Castable: AnyObject {
     /// Invoked when a Cast session has been established.
     ///
     /// - Returns: The current state.
+    @MainActor
     func castStartSession() -> CastResumeState?
 
     /// Invoked when the Cast session is about to stop.
     ///
     /// - Parameter state: The state immediately before the Cast session ends.
+    @MainActor
     func castEndSession(with state: CastResumeState?)
 }


### PR DESCRIPTION
## Description

This PR loosens main actor requirements introduced in #292. Marking a protocol as `@MainActor` namely forces conforming types to be `@MainActor` as well, which is too [restrictive](https://www.swiftbysundell.com/articles/swift-protocols-and-the-main-actor/) in our case. We just need the methods themselves to be marked with `@MainActor`.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
