### PR TITLE
Ensure proper color customization for CastButton

### DIFF
--- a/Demo/Sources/Player/LocalPlayerView.swift
+++ b/Demo/Sources/Player/LocalPlayerView.swift
@@ -84,9 +84,7 @@ private extension LocalPlayerView {
     }
 
     func closeButton() -> some View {
-        Button {
-            dismiss()
-        } label: {
+        Button(action: dismiss.callAsFunction) {
             Image(systemName: "xmark")
         }
         .padding()

--- a/Demo/Sources/Player/PlaylistSelectionView.swift
+++ b/Demo/Sources/Player/PlaylistSelectionView.swift
@@ -27,7 +27,7 @@ struct PlaylistSelectionView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button("Cancel", action: cancel)
+                Button("Cancel", action: dismiss.callAsFunction)
             }
             ToolbarItem(placement: .confirmationAction) {
                 Button("Add", action: add)
@@ -75,10 +75,6 @@ struct PlaylistSelectionView: View {
             LabeledContent("Multiplier", value: "×\(multiplier)")
         }
         .padding()
-    }
-
-    private func cancel() {
-        dismiss()
     }
 
     private func add() {

--- a/Demo/Sources/Player/RemotePlayerView.swift
+++ b/Demo/Sources/Player/RemotePlayerView.swift
@@ -46,9 +46,7 @@ struct RemotePlayerView: View {
     }
 
     private func closeButton() -> some View {
-        Button {
-            dismiss()
-        } label: {
+        Button(action: dismiss.callAsFunction) {
             Image(systemName: "xmark")
         }
     }

--- a/Demo/Sources/Player/UnifiedPlayerView.swift
+++ b/Demo/Sources/Player/UnifiedPlayerView.swift
@@ -94,9 +94,7 @@ private extension UnifiedPlayerView {
     }
 
     func closeButton() -> some View {
-        Button {
-            dismiss()
-        } label: {
+        Button(action: dismiss.callAsFunction) {
             Image(systemName: "xmark")
         }
         .padding()

--- a/Sources/Castor/Castor.docc/Articles/user-interface/user-interface-article.md
+++ b/Sources/Castor/Castor.docc/Articles/user-interface/user-interface-article.md
@@ -15,8 +15,6 @@ Integrate the Cast experience into your application.
 
 Castor includes several built-in views to cover common Cast use cases.
 
-> Tip: By default, the provided views use the `.accentColor`. You can change this color using the `.foregroundStyle` modifier, but note that this will not affect the color within the child views or a ``SwiftUI/Slider`` color. To update the default `accentColor` in the view displayed by the ``CastButton``, use the `.tint` modifier.
-
 ### Cast button
 
 ``CastButton`` is a SwiftUI view that displays a receiver selection popover (or a modal sheet, depending on the available width) and automatically reflects the current connection state.

--- a/Sources/Castor/UserInterface/CastButton.swift
+++ b/Sources/Castor/UserInterface/CastButton.swift
@@ -42,6 +42,11 @@ public struct CastButton: View {
     }
 
     /// Creates a Cast button.
+    /// 
+    /// - Parameters:
+    ///   - cast: The Cast object.
+    ///   - color: The color to apply to the button icon and devices view.
+    ///   - isPresenting: A binding that indicates whether the popover is presented.
     public init(cast: Cast, color: Color = .accentColor, isPresenting: Binding<Bool> = .constant(false)) {
         self.cast = cast
         self.color = color

--- a/Sources/Castor/UserInterface/CastButton.swift
+++ b/Sources/Castor/UserInterface/CastButton.swift
@@ -16,6 +16,7 @@ public struct CastButton: View {
     @Binding private var isPresenting: Bool
 
     @State private var isPresented = false
+    private let color: Color
 
     // swiftlint:disable:next missing_docs
     public var body: some View {
@@ -23,11 +24,12 @@ public struct CastButton: View {
             isPresented = true
         } label: {
             CastIcon(cast: cast)
+                .foregroundStyle(color)
         }
         .accessibilityHint(accessibilityHint)
         .popover(isPresented: $isPresented) {
             NavigationStack {
-                CastDevicesView(cast: cast)
+                CastDevicesView(cast: cast, color: color)
                     .font(nil)
                     .foregroundColor(nil)
                     .tint(nil)
@@ -40,8 +42,9 @@ public struct CastButton: View {
     }
 
     /// Creates a Cast button.
-    public init(cast: Cast, isPresenting: Binding<Bool> = .constant(false)) {
+    public init(cast: Cast, color: Color = .accentColor, isPresenting: Binding<Bool> = .constant(false)) {
         self.cast = cast
+        self.color = color
         _isPresenting = isPresenting
     }
 }

--- a/Sources/Castor/UserInterface/Devices/CastDeviceCell.swift
+++ b/Sources/Castor/UserInterface/Devices/CastDeviceCell.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct CastDeviceCell: View {
     let device: CastDevice
     let cast: Cast
+    let color: Color
 
     var body: some View {
         Button {
@@ -18,6 +19,7 @@ struct CastDeviceCell: View {
                 descriptionView(for: device)
             } icon: {
                 Image(systemName: CastDevice.imageName(for: device))
+                    .foregroundStyle(color)
             }
             .contentShape(.rect)
         }

--- a/Sources/Castor/UserInterface/Devices/CastDevicesView.swift
+++ b/Sources/Castor/UserInterface/Devices/CastDevicesView.swift
@@ -78,11 +78,15 @@ struct CastDevicesView: View {
         }
     }
 
+    @ViewBuilder
     private func closeButton() -> some View {
-        Button {
-            dismiss()
-        } label: {
-            Text("Close", bundle: .module, comment: "Close button")
+        if #available(iOS 26.0, *) {
+            Button(role: .close, action: dismiss.callAsFunction)
+        }
+        else {
+            Button(action: dismiss.callAsFunction) {
+                Text("Close", bundle: .module, comment: "Close button")
+            }
         }
     }
 

--- a/Sources/Castor/UserInterface/Devices/CastDevicesView.swift
+++ b/Sources/Castor/UserInterface/Devices/CastDevicesView.swift
@@ -10,11 +10,12 @@ import SwiftUI
 struct CastDevicesView: View {
     @ObservedObject var cast: Cast
     @Environment(\.dismiss) private var dismiss
+    let color: Color
 
     var body: some View {
         ZStack {
             if cast.devices.isEmpty {
-                EmptyDevicesView()
+                EmptyDevicesView(color: color)
             }
             else {
                 devicesList()
@@ -42,7 +43,7 @@ struct CastDevicesView: View {
     private func currentDeviceSection() -> some View {
         if let currentDevice = cast.currentDevice {
             Section {
-                CurrentCastDeviceCell(device: currentDevice, cast: cast)
+                CurrentCastDeviceCell(device: currentDevice, cast: cast, color: color)
             } header: {
                 Text("Current device", bundle: .module, comment: "Header for displaying current device information")
             }
@@ -55,7 +56,7 @@ struct CastDevicesView: View {
         if !devices.isEmpty {
             Section {
                 ForEach(devices) { device in
-                    MultizoneDeviceCell(device: device, cast: cast)
+                    MultizoneDeviceCell(device: device, cast: cast, color: color)
                 }
             } header: {
                 Text("Paired devices", bundle: .module, comment: "Header for the paired devices list section")
@@ -69,7 +70,7 @@ struct CastDevicesView: View {
         if !devices.isEmpty {
             Section {
                 ForEach(devices) { device in
-                    CastDeviceCell(device: device, cast: cast)
+                    CastDeviceCell(device: device, cast: cast, color: color)
                 }
             } header: {
                 Text("Available devices", bundle: .module, comment: "Header for available devices list section")

--- a/Sources/Castor/UserInterface/Devices/CurrentCastDeviceCell.swift
+++ b/Sources/Castor/UserInterface/Devices/CurrentCastDeviceCell.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct CurrentCastDeviceCell: View {
     let device: CastDevice
     @ObservedObject var cast: Cast
+    let color: Color
 
     var body: some View {
         VStack(spacing: 20) {
@@ -16,8 +17,10 @@ struct CurrentCastDeviceCell: View {
                 descriptionView()
             } icon: {
                 CastIcon(cast: cast)
+                    .foregroundStyle(color)
             }
             CastVolumeSlider(deviceManager: cast.deviceManager())
+                .tint(color)
             disconnectButton()
         }
     }
@@ -42,6 +45,7 @@ struct CurrentCastDeviceCell: View {
     private func disconnectButton() -> some View {
         Button(action: cast.endSession) {
             Text("Disconnect", bundle: .module, comment: "Label of the button to disconnect from a Cast receiver")
+                .foregroundStyle(color)
         }
         // Trick to avoid tapping on the entire cell.
         .buttonStyle(.borderless)

--- a/Sources/Castor/UserInterface/Devices/MultizoneDeviceCell.swift
+++ b/Sources/Castor/UserInterface/Devices/MultizoneDeviceCell.swift
@@ -9,11 +9,13 @@ import SwiftUI
 struct MultizoneDeviceCell: View {
     let device: CastMultizoneDevice
     let cast: Cast
+    let color: Color
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             descriptionView()
             CastVolumeSlider(deviceManager: cast.deviceManager(forMultizoneDevice: device))
+                .tint(color)
         }
     }
 

--- a/Sources/Castor/UserInterface/EmptyDevicesView.swift
+++ b/Sources/Castor/UserInterface/EmptyDevicesView.swift
@@ -7,6 +7,8 @@
 import SwiftUI
 
 struct EmptyDevicesView: View {
+    let color: Color
+
     var body: some View {
         UnavailableView {
             Label {
@@ -23,6 +25,7 @@ struct EmptyDevicesView: View {
             if canOpenSettings() {
                 Button(action: openSettings) {
                     Text("Open Settings", bundle: .module, comment: "Open settings button accessibility label")
+                        .foregroundStyle(color)
                 }
             }
         }
@@ -59,5 +62,5 @@ private extension EmptyDevicesView {
 }
 
 #Preview {
-    EmptyDevicesView()
+    EmptyDevicesView(color: .accentColor)
 }


### PR DESCRIPTION
## Description

This PR allows us to customize the color of the `CastButton` and propagates this color through the child views (`CastDevicesView`, `CastDeviceCell`, `CurrentCastDeviceCell`, `MultizoneDeviceCell`, and `EmptyDevicesView`).

## Changes made

- A color parameter was added on the `CastButton`.
- The dismiss button actions have been simplified (usage of `callAsFunction`).

## Overview

> [!NOTE] 
> These videos were recorded without defining an `accentColor`. A green color has been set as the desired color.

| Issue | Fix |
|--------|--------|
|  <video src="https://github.com/user-attachments/assets/cfb75882-f741-4a84-9c18-7020e3e3651a" /> |  <video src="https://github.com/user-attachments/assets/5f6d9d71-2c33-4cd1-9064-256c7f0ca3c2" /> | 

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
