### PR TITLE
Enable standard APIs for Cast button styling

### DIFF
--- a/Sources/Castor/UserInterface/CastButton.swift
+++ b/Sources/Castor/UserInterface/CastButton.swift
@@ -24,7 +24,6 @@ public struct CastButton: View {
             isPresented = true
         } label: {
             CastIcon(cast: cast)
-                .foregroundStyle(color)
         }
         .accessibilityHint(accessibilityHint)
         .popover(isPresented: $isPresented) {
@@ -45,7 +44,7 @@ public struct CastButton: View {
     /// 
     /// - Parameters:
     ///   - cast: The Cast object.
-    ///   - color: The color to apply to the button icon and devices view.
+    ///   - color: The color to apply to the devices view.
     ///   - isPresenting: A binding that indicates whether the popover is presented.
     public init(cast: Cast, color: Color = .accentColor, isPresenting: Binding<Bool> = .constant(false)) {
         self.cast = cast


### PR DESCRIPTION
## Description

This PR is an improvement of #295, which introduced a single color for the Cast button and its associated views. This was preventing legitimate use of standard styling APis like `foregroundStyle`, though, possibly applied using a button style.

To solve this issue this PR only applies the color associated with a Cast button to its associated views. The color of the button can therefore be controlled separately.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
