### PR TITLE
Allow configuration via default creation and selected mutation

### DIFF
--- a/Demo/Sources/Player/LocalPlaybackView.swift
+++ b/Demo/Sources/Player/LocalPlaybackView.swift
@@ -253,7 +253,7 @@ struct LocalPlaybackView: View {
         LazyImage(source: player.metadata.imageSource) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
         }
         .opacity(player.mediaType == .audio ? 1 : 0)
     }

--- a/Demo/Sources/Player/RemotePlaybackView.swift
+++ b/Demo/Sources/Player/RemotePlaybackView.swift
@@ -175,7 +175,7 @@ struct RemotePlaybackView: View {
         AsyncImage(url: player.currentAsset?.metadata?.imageUrl()) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
         } placeholder: {
             EmptyView()
         }

--- a/Sources/Castor/Cast/CastConfiguration.swift
+++ b/Sources/Castor/Cast/CastConfiguration.swift
@@ -11,13 +11,13 @@ import AVFoundation
 /// The configuration defines behaviors set when the ``Cast`` object is created and cannot be changed afterwards.
 public struct CastConfiguration {
     /// The navigation mode.
-    public let navigationMode: CastNavigationMode
-
-    /// The forward skip interval in seconds.
-    public let forwardSkipInterval: TimeInterval
+    public var navigationMode: CastNavigationMode
 
     /// The backward skip interval in seconds.
-    public let backwardSkipInterval: TimeInterval
+    public var backwardSkipInterval: TimeInterval
+
+    /// The forward skip interval in seconds.
+    public var forwardSkipInterval: TimeInterval
 
     /// Creates a configuration.
     ///

--- a/Sources/Castor/Types/CastAssetURLConfiguration.swift
+++ b/Sources/Castor/Types/CastAssetURLConfiguration.swift
@@ -9,13 +9,13 @@ import GoogleCast
 /// The configuration associated with a URL-based asset.
 public struct CastAssetURLConfiguration {
     /// The MIME type of the asset.
-    public let mimeType: String?
+    public var mimeType: String?
 
     /// The audio segment format (HLS streams only).
-    public let hlsAudioSegmentFormat: GCKHLSSegmentFormat
+    public var hlsAudioSegmentFormat: GCKHLSSegmentFormat
 
     /// The video segment format (HLS streams only).
-    public let hlsVideoSegmentFormat: GCKHLSVideoSegmentFormat
+    public var hlsVideoSegmentFormat: GCKHLSVideoSegmentFormat
 
     /// Creates a configuration for a URL-based asset.
     ///

--- a/Sources/Castor/UserInterface/ArtworkImage.swift
+++ b/Sources/Castor/UserInterface/ArtworkImage.swift
@@ -12,12 +12,12 @@ struct ArtworkImage: View {
     var body: some View {
         Rectangle()
             .fill(.primary.opacity(0.2))
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .overlay {
                 AsyncImage(url: url) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     EmptyView()
                 }


### PR DESCRIPTION
## Description

This PR improves configuration API ergonomics to account for selected conditional mutation. Imagine for example that an app has settings for skip intervals:

```swift
struct AppSettings {
    let backwardSkipInterval: TimeInterval?
    let forwardSkipInterval: TimeInterval?
}
```

where `nil` means _default value_.

Currently, configuring `CastConfiguration` is a PITA. Either you have to supply the default values manually or use several branches:

```swift
extension AppSettings {
    var castConfiguration1: CastConfiguration {
        .init(backwardSkipInterval: backwardSkipInterval ?? 0, forwardSkipInterval: forwardSkipInterval ?? 10)
    }

    var castConfiguration2: CastConfiguration {
        if let backwardSkipInterval {
            if let forwardSkipInterval {
                return .init(backwardSkipInterval: backwardSkipInterval, forwardSkipInterval: forwardSkipInterval)
            }
            else {
                return .init(backwardSkipInterval: backwardSkipInterval)
            }
        }
        else if let forwardSkipInterval {
            return .init(forwardSkipInterval: forwardSkipInterval)
        }
        else {
            return .init()
        }
    }
}
```
 
This PR simply enables post-construction mutation to better account for such use cases:

```swift
extension AppSettings {
    var castConfiguration3: CastConfiguration {
        var configuration = CastConfiguration()
        if let forwardSkipInterval {
            configuration.forwardSkipInterval = forwardSkipInterval
        }
        if let backwardSkipInterval {
            configuration.backwardSkipInterval = backwardSkipInterval
        }
        return configuration
    }
}
```

The usual initializer construction remains of course available.

### Remark

This improvement idea was motivated by a [new configuration type](https://github.com/SRGSSR/pillarbox-apple/issues/1434) added to Pillarbox.

## Changes made

- Made `CastConfiguration` and `CastAssetURLConfiguration` properties mutable.
- Fixed linting issues with recent SwiftLint versions.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The behavior works with all receivers available in the demo.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
